### PR TITLE
 Added missing AIX definition for sched.h (previously out of scope).

### DIFF
--- a/include/boost/container/detail/mutex.hpp
+++ b/include/boost/container/detail/mutex.hpp
@@ -25,6 +25,10 @@
 #include <boost/container/detail/config_begin.hpp>
 #include <boost/container/detail/workaround.hpp>
 
+#ifdef _AIX
+#include <sched.h>
+#endif
+
 // Extremely Light-Weight wrapper classes for OS thread synchronization
 
 #define BOOST_MUTEX_HELPER_NONE         0


### PR DESCRIPTION
In mutex.hpp there was a compilation failure because, "'sched_yield' was not declared in this scope." As a result, I added the missing file (sched.h) in AIX to allow it to see the function.
