### PR TITLE
Support for std::initializer_list in stable_vector

### DIFF
--- a/include/boost/container/stable_vector.hpp
+++ b/include/boost/container/stable_vector.hpp
@@ -56,6 +56,10 @@
 namespace boost {
 namespace container {
 
+#if !defined(BOOST_NO_CXX11_HDR_INITIALIZER_LIST)
+#include <initializer_list>
+#endif
+
 #ifndef BOOST_CONTAINER_DOXYGEN_INVOKED
 
 namespace stable_vector_detail{
@@ -628,6 +632,24 @@ class stable_vector
       cod.release();
    }
 
+#if !defined(BOOST_NO_CXX11_HDR_INITIALIZER_LIST)
+   //! <b>Effects</b>: Constructs a stable_vector that will use a copy of allocator a
+   //!  and inserts a copy of the range [il.begin(), il.last()) in the stable_vector
+   //!
+   //! <b>Throws</b>: If allocator_type's default constructor
+   //!   throws or T's constructor taking a dereferenced initializer_list iterator throws.
+   //!
+   //! <b>Complexity</b>: Linear to the range [il.begin(), il.end()).
+   stable_vector(std::initializer_list<value_type> il, const allocator_type& l = allocator_type())
+      : internal_data(l), index(l)
+   {
+       stable_vector_detail::clear_on_destroy<stable_vector> cod(*this);
+       insert(cend(), il.begin(), il.end())
+       STABLE_VECTOR_CHECK_INVARIANT;
+       cod.release();
+   }
+#endif
+
    //! <b>Effects</b>: Move constructor. Moves mx's resources to *this.
    //!
    //! <b>Throws</b>: If allocator_type's copy constructor throws.
@@ -753,6 +775,20 @@ class stable_vector
       return *this;
    }
 
+#if !defined(BOOST_NO_CXX11_HDR_INITIALIZER_LIST)
+   //! <b>Effects</b>: Make *this container contains elements from il.
+   //!
+   //! <b>Complexity</b>: Linear to the range [il.begin(), il.end()).
+   stable_vector& operator=(std::initializer_list<value_type> il)
+   {
+      STABLE_VECTOR_CHECK_INVARIANT;
+      clear();
+      shrink_to_fit();
+      assign(il.begin(), il.end());
+      return *this;
+   }
+#endif
+
    //! <b>Effects</b>: Assigns the n copies of val to *this.
    //!
    //! <b>Throws</b>: If memory allocation throws or T's copy constructor throws.
@@ -791,6 +827,19 @@ class stable_vector
          this->insert(last1, first, last);
       }
    }
+
+#if !defined(BOOST_NO_CXX11_HDR_INITIALIZER_LIST)
+   //! <b>Effects</b>: Assigns the the range [il.begin(), il.end()) to *this.
+   //!
+   //! <b>Throws</b>: If memory allocation throws or
+   //!   T's constructor from dereferencing initializer_list iterator throws.
+   //!
+   void assign(std::initializer_list<value_type> il)
+   {
+       STABLE_VECTOR_CHECK_INVARIANT;
+       assign(il.begin(), il.end());
+   }
+#endif
 
    //! <b>Effects</b>: Returns a copy of the internal allocator.
    //!
@@ -1344,6 +1393,21 @@ class stable_vector
       typedef constant_iterator<value_type, difference_type> cvalue_iterator;
       return this->insert(position, cvalue_iterator(t, n), cvalue_iterator());
    }
+
+#if !defined(BOOST_NO_CXX11_HDR_INITIALIZER_LIST)
+   //! <b>Requires</b>: position must be a valid iterator of *this.
+   //!
+   //! <b>Effects</b>: Insert a copy of the [il.begin(), il.end()) range before position.
+   //!
+   //! <b>Returns</b>: an iterator to the first inserted element or position if first == last.
+   //!
+   //! <b>Complexity</b>: Linear to std::distance [il.begin(), il.end()).
+   iterator insert(const_iterator position, std::initializer_list<value_type> il)
+   {
+       STABLE_VECTOR_CHECK_INVARIANT;
+      return insert(position, il.begin(), il.end());
+   }
+#endif
 
    //! <b>Requires</b>: pos must be a valid iterator of *this.
    //!

--- a/test/stable_vector_test.cpp
+++ b/test/stable_vector_test.cpp
@@ -112,6 +112,44 @@ int test_cont_variants()
    return 0;
 }
 
+bool test_methods_with_initializer_list_as_argument()
+{
+#if !defined(BOOST_NO_CXX11_HDR_INITIALIZER_LIST)
+   {
+      const stable_vector<int> testedVector = {1, 2, 3};
+      const std::vector<int> expectedVector = {1, 2, 3};
+      if(!test::CheckEqualContainers(&testedVector, &expectedVector)) return false;
+   }
+
+   {
+       stable_vector<int> testedVector = {1, 2, 3};
+       testedVector = {11, 12, 13};
+
+       const std::vector<int> expectedVector = {11, 12, 13};
+       if(!test::CheckEqualContainers(&testedVector, &expectedVector)) return false;
+   }
+
+   {
+       stable_vector<int> testedVector = {1, 2, 3};
+       testedVector.assign({5, 6, 7});
+
+       const std::vector<int> expectedVector = {5, 6, 7};
+       if(!test::CheckEqualContainers(&testedVector, &expectedVector)) return false;
+   }
+
+   {
+       stable_vector<int> testedVector = {1, 2, 3};
+       testedVector.insert(testedVector.cend(), {5, 6, 7});
+
+       const std::vector<int> expectedVector = {1, 2, 3, 5, 6, 7};
+       if(!test::CheckEqualContainers(&testedVector, &expectedVector)) return false;
+   }
+       return true;
+#else
+    return true;
+#endif
+}
+
 int main()
 {
    recursive_vector_test();
@@ -177,6 +215,12 @@ int main()
    ////////////////////////////////////
    if(!boost::container::test::test_propagate_allocator<stable_vector>())
       return 1;
+
+   if(!test_methods_with_initializer_list_as_argument())
+   {
+       std::cerr << "test_methods_with_initializer_list_as_argument failed" << std::endl;
+       return 1;
+   }
 
    return 0;
 }


### PR DESCRIPTION
I miss support for std::initializer_list in some container methods, so I prepared patch that implements it for following method of stable vector (if the std::initializer_list is supported by the compiler):
- constructor
- operator=
- assign
- insert
  I also added some simple tests, they pass with g++ and clang++.

If this patch will pass a review and be included in boost::container repository I will add similar support for other boost containers.
