### PR TITLE
Fix iterators of incomplete type containers

### DIFF
--- a/include/boost/container/detail/iterators.hpp
+++ b/include/boost/container/detail/iterators.hpp
@@ -698,11 +698,16 @@ struct is_bidirectional_iterator<T, false>
    static const bool value = false;
 };
 
+template<class IINodeType>
+struct iiterator_node_value_type {
+  typedef typename IINodeType::value_type type;
+};
+
 template<class IIterator>
 struct iiterator_types
 {
    typedef typename IIterator::value_type                            it_value_type;
-   typedef typename it_value_type::value_type                        value_type;
+   typedef typename iiterator_node_value_type<it_value_type>::type   value_type;
    typedef typename std::iterator_traits<IIterator>::pointer         it_pointer;
    typedef typename std::iterator_traits<IIterator>::difference_type difference_type;
    typedef typename ::boost::intrusive::pointer_traits<it_pointer>::

--- a/include/boost/container/detail/tree.hpp
+++ b/include/boost/container/detail/tree.hpp
@@ -216,6 +216,11 @@ struct tree_node
    {  m_data = ::boost::move(v); }
 };
 
+template <class T, class VoidPointer, boost::container::tree_type_enum tree_type_value, bool OptimizeSize>
+struct iiterator_node_value_type< tree_node<T, VoidPointer, tree_type_value, OptimizeSize> > {
+  typedef T type;
+};
+
 template<class Node, class Icont>
 class insert_equal_end_hint_functor
 {

--- a/include/boost/container/list.hpp
+++ b/include/boost/container/list.hpp
@@ -81,6 +81,11 @@ struct list_node
    {  return this->m_data;   }
 };
 
+template <class T, class VoidPointer>
+struct iiterator_node_value_type< list_node<T,VoidPointer> > {
+  typedef T type;
+};
+
 template<class Allocator>
 struct intrusive_list_type
 {

--- a/include/boost/container/slist.hpp
+++ b/include/boost/container/slist.hpp
@@ -87,6 +87,11 @@ struct slist_node
    {  return this->m_data;   }
 };
 
+template <class T, class VoidPointer>
+struct iiterator_node_value_type< slist_node<T,VoidPointer> > {
+  typedef T type;
+};
+
 template<class Allocator>
 struct intrusive_slist_type
 {

--- a/test/deque_test.cpp
+++ b/test/deque_test.cpp
@@ -138,6 +138,10 @@ public:
 
    int id_;
    deque<recursive_deque> deque_;
+   deque<recursive_deque>::iterator it_;
+   deque<recursive_deque>::const_iterator cit_;
+   deque<recursive_deque>::reverse_iterator rit_;
+   deque<recursive_deque>::const_reverse_iterator crit_;
 };
 
 template<class IntType>

--- a/test/flat_map_test.cpp
+++ b/test/flat_map_test.cpp
@@ -150,6 +150,10 @@ class recursive_flat_map
 
    int id_;
    flat_map<recursive_flat_map, recursive_flat_map> map_;
+   flat_map<recursive_flat_map, recursive_flat_map>::iterator it_;
+   flat_map<recursive_flat_map, recursive_flat_map>::const_iterator cit_;
+   flat_map<recursive_flat_map, recursive_flat_map>::reverse_iterator rit_;
+   flat_map<recursive_flat_map, recursive_flat_map>::const_reverse_iterator crit_;
 
    friend bool operator< (const recursive_flat_map &a, const recursive_flat_map &b)
    {  return a.id_ < b.id_;   }
@@ -170,7 +174,12 @@ public:
       return *this;
    }
    int id_;
-   flat_map<recursive_flat_multimap, recursive_flat_multimap> map_;
+   flat_multimap<recursive_flat_multimap, recursive_flat_multimap> map_;
+   flat_multimap<recursive_flat_multimap, recursive_flat_multimap>::iterator it_;
+   flat_multimap<recursive_flat_multimap, recursive_flat_multimap>::const_iterator cit_;
+   flat_multimap<recursive_flat_multimap, recursive_flat_multimap>::reverse_iterator rit_;
+   flat_multimap<recursive_flat_multimap, recursive_flat_multimap>::const_reverse_iterator crit_;
+   
    friend bool operator< (const recursive_flat_multimap &a, const recursive_flat_multimap &b)
    {  return a.id_ < b.id_;   }
 };

--- a/test/flat_set_test.cpp
+++ b/test/flat_set_test.cpp
@@ -179,6 +179,11 @@ class recursive_flat_set
    }
    int id_;
    flat_set<recursive_flat_set> flat_set_;
+   flat_set<recursive_flat_set>::iterator it_;
+   flat_set<recursive_flat_set>::const_iterator cit_;
+   flat_set<recursive_flat_set>::reverse_iterator rit_;
+   flat_set<recursive_flat_set>::const_reverse_iterator crit_;
+   
    friend bool operator< (const recursive_flat_set &a, const recursive_flat_set &b)
    {  return a.id_ < b.id_;   }
 };
@@ -200,6 +205,11 @@ class recursive_flat_multiset
    }
    int id_;
    flat_multiset<recursive_flat_multiset> flat_multiset_;
+   flat_multiset<recursive_flat_multiset>::iterator it_;
+   flat_multiset<recursive_flat_multiset>::const_iterator cit_;
+   flat_multiset<recursive_flat_multiset>::reverse_iterator rit_;
+   flat_multiset<recursive_flat_multiset>::const_reverse_iterator crit_;
+   
    friend bool operator< (const recursive_flat_multiset &a, const recursive_flat_multiset &b)
    {  return a.id_ < b.id_;   }
 };

--- a/test/list_test.cpp
+++ b/test/list_test.cpp
@@ -67,6 +67,11 @@ class recursive_list
 public:
    int id_;
    list<recursive_list> list_;
+   list<recursive_list>::iterator it_;
+   list<recursive_list>::const_iterator cit_;
+   list<recursive_list>::reverse_iterator rit_;
+   list<recursive_list>::const_reverse_iterator crit_;
+   
    recursive_list &operator=(const recursive_list &o)
    { list_ = o.list_;  return *this; }
 };

--- a/test/map_test.cpp
+++ b/test/map_test.cpp
@@ -195,6 +195,11 @@ class recursive_map
 
    int id_;
    map<recursive_map, recursive_map> map_;
+   map<recursive_map, recursive_map>::iterator it_;
+   map<recursive_map, recursive_map>::const_iterator cit_;
+   map<recursive_map, recursive_map>::reverse_iterator rit_;
+   map<recursive_map, recursive_map>::const_reverse_iterator crit_;
+   
    friend bool operator< (const recursive_map &a, const recursive_map &b)
    {  return a.id_ < b.id_;   }
 };
@@ -207,6 +212,11 @@ class recursive_multimap
 
    int id_;
    multimap<recursive_multimap, recursive_multimap> multimap_;
+   multimap<recursive_multimap, recursive_multimap>::iterator it_;
+   multimap<recursive_multimap, recursive_multimap>::const_iterator cit_;
+   multimap<recursive_multimap, recursive_multimap>::reverse_iterator rit_;
+   multimap<recursive_multimap, recursive_multimap>::const_reverse_iterator crit_;
+   
    friend bool operator< (const recursive_multimap &a, const recursive_multimap &b)
    {  return a.id_ < b.id_;   }
 };

--- a/test/set_test.cpp
+++ b/test/set_test.cpp
@@ -172,6 +172,11 @@ public:
 
    int id_;
    set<recursive_set> set_;
+   set<recursive_set>::iterator it_;
+   set<recursive_set>::const_iterator cit_;
+   set<recursive_set>::reverse_iterator rit_;
+   set<recursive_set>::const_reverse_iterator crit_;
+   
    friend bool operator< (const recursive_set &a, const recursive_set &b)
    {  return a.id_ < b.id_;   }
 };
@@ -185,6 +190,11 @@ class recursive_multiset
 
    int id_;
    multiset<recursive_multiset> multiset_;
+   multiset<recursive_multiset>::iterator it_;
+   multiset<recursive_multiset>::const_iterator cit_;
+   multiset<recursive_multiset>::reverse_iterator rit_;
+   multiset<recursive_multiset>::const_reverse_iterator crit_;
+   
    friend bool operator< (const recursive_multiset &a, const recursive_multiset &b)
    {  return a.id_ < b.id_;   }
 };

--- a/test/slist_test.cpp
+++ b/test/slist_test.cpp
@@ -57,6 +57,9 @@ class recursive_slist
 public:
    int id_;
    slist<recursive_slist> slist_;
+   slist<recursive_slist>::iterator it_;
+   slist<recursive_slist>::const_iterator cit_;
+   
    recursive_slist &operator=(const recursive_slist &o)
    { slist_ = o.slist_;  return *this; }
 };

--- a/test/stable_vector_test.cpp
+++ b/test/stable_vector_test.cpp
@@ -66,6 +66,11 @@ class recursive_vector
    public:
    int id_;
    stable_vector<recursive_vector> vector_;
+   stable_vector<recursive_vector>::iterator it_;
+   stable_vector<recursive_vector>::const_iterator cit_;
+   stable_vector<recursive_vector>::reverse_iterator rit_;
+   stable_vector<recursive_vector>::const_reverse_iterator crit_;
+   
    recursive_vector &operator=(const recursive_vector &o)
    { vector_ = o.vector_;  return *this; }
 };

--- a/test/vector_test.cpp
+++ b/test/vector_test.cpp
@@ -112,6 +112,10 @@ class recursive_vector
    public:
    int id_;
    vector<recursive_vector> vector_;
+   vector<recursive_vector>::iterator it_;
+   vector<recursive_vector>::const_iterator cit_;
+   vector<recursive_vector>::reverse_iterator rit_;
+   vector<recursive_vector>::const_reverse_iterator crit_;
 };
 
 void recursive_vector_test()//Test for recursive types


### PR DESCRIPTION
Issue:
The implementation of SCARY iterators from version 1.54 to 1.55 broke the ability to use iterators of containers of incomplete types. This was simply an unfortunate consequence of a slight short-cut taken in the SCARY iterator implementation. By invoking "it_value_type::value_type", where it_value_type is the "raw" value type of iterators, typically list_node, slist_node or tree_node, the compiler is required to instantiate these node class templates in order to retrieve the dependent type "value_type", and thus, it causes a compilation error when the actual value-type of the container is an incomplete type (making the node types incomplete as well).

Fix:
I did not manage to truly understand the ramifications of the iterator implementation under the hood. However, I came up with a very simple fix which replaces the it_value_type::value_type invocation by a simple meta-function iiterator_node_value_type, which is specialized for each node type (list_node, slist_node and tree_node). By adding iterators to the recursive container tests, it shows that it works (and it also works in other code that I have which requires this feature, which is why I wrote this fix!). Having iterators in those unit-tests should prevent future modifications from breaking this feature again.

To Do:
- Consider adopting a clearer guidelines in the documentation of the library about the guarantees for iterators of containers of incomplete types, instead of the vague statement that "all containers work for incomplete types". This feature is extremely important to Boost.Container, as it is one of the main motivations for using this library instead of STL implementation provided by the platform used. 

Commit:
Fixes a small issue that prevented the use of iterators of containers of incomplete types.
Added iterators of incomp-types to unit-tests.
