### PR TITLE
N3644 "Null Forward Iterator" compliance

### DIFF
--- a/include/boost/container/stable_vector.hpp
+++ b/include/boost/container/stable_vector.hpp
@@ -265,6 +265,7 @@ class stable_vector_iterator
    {}
 
    stable_vector_iterator() BOOST_CONTAINER_NOEXCEPT
+      : m_pn()
    {}
 
    stable_vector_iterator(stable_vector_iterator<Pointer, false> const& other) BOOST_CONTAINER_NOEXCEPT

--- a/include/boost/container/vector.hpp
+++ b/include/boost/container/vector.hpp
@@ -102,11 +102,7 @@ class vec_iterator
 
    //Constructors
    vec_iterator() BOOST_CONTAINER_NOEXCEPT
-      #ifndef NDEBUG
       : m_ptr()
-      #else
-      // No value initialization of m_ptr() to speed up things a bit:
-      #endif
    {}
 
    vec_iterator(vec_iterator<Pointer, false> const& other) BOOST_CONTAINER_NOEXCEPT

--- a/test/deque_test.cpp
+++ b/test/deque_test.cpp
@@ -75,6 +75,24 @@ bool deque_copyable_only(V1 *, V2 *, container_detail::false_type)
    return true;
 }
 
+template <class Iterator>
+bool test_value_init_iterator()
+{
+   // Create jumbled up memory to seat the iterator objects:
+   char c_arr[2*sizeof(Iterator)];
+   for(std::size_t i = 0; i < 2*sizeof(Iterator); ++i)
+      c_arr[i] = i;
+   Iterator* p_it1 = reinterpret_cast<Iterator*>(c_arr);
+   Iterator* p_it2 = reinterpret_cast<Iterator*>(c_arr + sizeof(Iterator));
+   // Do a placement value-initialization of iterators:
+   new(p_it1) Iterator();
+   new(p_it2) Iterator();
+   bool result = (*p_it1 == *p_it2);
+   p_it2->~Iterator();
+   p_it1->~Iterator();
+   return result;
+}
+
 //Function to check if both sets are equal
 template<class V1, class V2>
 bool deque_copyable_only(V1 *cntdeque, V2 *stddeque, container_detail::true_type)
@@ -446,6 +464,29 @@ int main ()
    ////////////////////////////////////
    if(!boost::container::test::test_propagate_allocator<deque>())
       return 1;
+
+   ////////////////////////////////////
+   //    n3644 "Null forward iterator" test:
+   ////////////////////////////////////
+   { 
+      typedef deque<int> cont_t;
+      if(!test_value_init_iterator<cont_t::iterator>()){
+         std::cerr << "test for n3644 failed on iterator on deque" << std::endl;
+         return 1;
+      }
+      if(!test_value_init_iterator<cont_t::const_iterator>()){
+         std::cerr << "test for n3644 failed on const_iterator on deque" << std::endl;
+         return 1;
+      }
+      if(!test_value_init_iterator<cont_t::reverse_iterator>()){
+         std::cerr << "test for n3644 failed on reverse_iterator on deque" << std::endl;
+         return 1;
+      }
+      if(!test_value_init_iterator<cont_t::const_reverse_iterator>()){
+         std::cerr << "test for n3644 failed on const_reverse_iterator on deque" << std::endl;
+         return 1;
+      }
+   }
 
    return 0;
 }

--- a/test/flat_map_test.cpp
+++ b/test/flat_map_test.cpp
@@ -195,6 +195,24 @@ void test_move()
    move_assign.swap(original);
 }
 
+template <class Iterator>
+bool test_value_init_iterator()
+{
+   // Create jumbled up memory to seat the iterator objects:
+   char c_arr[2*sizeof(Iterator)];
+   for(std::size_t i = 0; i < 2*sizeof(Iterator); ++i)
+      c_arr[i] = i;
+   Iterator* p_it1 = reinterpret_cast<Iterator*>(c_arr);
+   Iterator* p_it2 = reinterpret_cast<Iterator*>(c_arr + sizeof(Iterator));
+   // Do a placement value-initialization of iterators:
+   new(p_it1) Iterator();
+   new(p_it2) Iterator();
+   bool result = (*p_it1 == *p_it2);
+   p_it2->~Iterator();
+   p_it1->~Iterator();
+   return result;
+}
+
 template<class T, class A>
 class flat_map_propagate_test_wrapper
    : public boost::container::flat_map
@@ -498,6 +516,48 @@ int main()
    ////////////////////////////////////
    if(!boost::container::test::test_propagate_allocator<flat_map_propagate_test_wrapper>())
       return 1;
+
+   ////////////////////////////////////
+   //    n3644 "Null forward iterator" test:
+   ////////////////////////////////////
+   { 
+      typedef flat_map<int, int> cont_t;
+      if(!test_value_init_iterator<cont_t::iterator>()){
+         std::cerr << "test for n3644 failed on iterator on flat_map" << std::endl;
+         return 1;
+      }
+      if(!test_value_init_iterator<cont_t::const_iterator>()){
+         std::cerr << "test for n3644 failed on const_iterator on flat_map" << std::endl;
+         return 1;
+      }
+      if(!test_value_init_iterator<cont_t::reverse_iterator>()){
+         std::cerr << "test for n3644 failed on reverse_iterator on flat_map" << std::endl;
+         return 1;
+      }
+      if(!test_value_init_iterator<cont_t::const_reverse_iterator>()){
+         std::cerr << "test for n3644 failed on const_reverse_iterator on flat_map" << std::endl;
+         return 1;
+      }
+   }
+   { 
+      typedef flat_multimap<int, int> cont_t;
+      if(!(cont_t::iterator() == cont_t::iterator())){
+         std::cerr << "test for n3644 failed on iterator on flat_multimap" << std::endl;
+         return 1;
+      }
+      if(!(cont_t::const_iterator() == cont_t::const_iterator())){
+         std::cerr << "test for n3644 failed on const_iterator on flat_multimap" << std::endl;
+         return 1;
+      }
+      if(!(cont_t::reverse_iterator() == cont_t::reverse_iterator())){
+         std::cerr << "test for n3644 failed on reverse_iterator on flat_multimap" << std::endl;
+         return 1;
+      }
+      if(!(cont_t::const_reverse_iterator() == cont_t::const_reverse_iterator())){
+         std::cerr << "test for n3644 failed on const_reverse_iterator on flat_multimap" << std::endl;
+         return 1;
+      }
+   }
 
    return 0;
 }

--- a/test/flat_set_test.cpp
+++ b/test/flat_set_test.cpp
@@ -226,6 +226,24 @@ void test_move()
    move_assign.swap(original);
 }
 
+template <class Iterator>
+bool test_value_init_iterator()
+{
+   // Create jumbled up memory to seat the iterator objects:
+   char c_arr[2*sizeof(Iterator)];
+   for(std::size_t i = 0; i < 2*sizeof(Iterator); ++i)
+      c_arr[i] = i;
+   Iterator* p_it1 = reinterpret_cast<Iterator*>(c_arr);
+   Iterator* p_it2 = reinterpret_cast<Iterator*>(c_arr + sizeof(Iterator));
+   // Do a placement value-initialization of iterators:
+   new(p_it1) Iterator();
+   new(p_it2) Iterator();
+   bool result = (*p_it1 == *p_it2);
+   p_it2->~Iterator();
+   p_it1->~Iterator();
+   return result;
+}
+
 template<class T, class A>
 class flat_set_propagate_test_wrapper
    : public boost::container::flat_set<T, std::less<T>, A>
@@ -584,6 +602,48 @@ int main()
    ////////////////////////////////////
    if(!boost::container::test::test_propagate_allocator<flat_set_propagate_test_wrapper>())
       return 1;
+
+   ////////////////////////////////////
+   //    n3644 "Null forward iterator" test:
+   ////////////////////////////////////
+   { 
+      typedef flat_set<int> cont_t;
+      if(!test_value_init_iterator<cont_t::iterator>()){
+         std::cerr << "test for n3644 failed on iterator on flat_set" << std::endl;
+         return 1;
+      }
+      if(!test_value_init_iterator<cont_t::const_iterator>()){
+         std::cerr << "test for n3644 failed on const_iterator on flat_set" << std::endl;
+         return 1;
+      }
+      if(!test_value_init_iterator<cont_t::reverse_iterator>()){
+         std::cerr << "test for n3644 failed on reverse_iterator on flat_set" << std::endl;
+         return 1;
+      }
+      if(!test_value_init_iterator<cont_t::const_reverse_iterator>()){
+         std::cerr << "test for n3644 failed on const_reverse_iterator on flat_set" << std::endl;
+         return 1;
+      }
+   }
+   { 
+      typedef flat_multiset<int> cont_t;
+      if(!test_value_init_iterator<cont_t::iterator>()){
+         std::cerr << "test for n3644 failed on iterator on flat_multiset" << std::endl;
+         return 1;
+      }
+      if(!test_value_init_iterator<cont_t::const_iterator>()){
+         std::cerr << "test for n3644 failed on const_iterator on flat_multiset" << std::endl;
+         return 1;
+      }
+      if(!test_value_init_iterator<cont_t::reverse_iterator>()){
+         std::cerr << "test for n3644 failed on reverse_iterator on flat_multiset" << std::endl;
+         return 1;
+      }
+      if(!test_value_init_iterator<cont_t::const_reverse_iterator>()){
+         std::cerr << "test for n3644 failed on const_reverse_iterator on flat_multiset" << std::endl;
+         return 1;
+      }
+   }
 
    return 0;
 }

--- a/test/list_test.cpp
+++ b/test/list_test.cpp
@@ -85,6 +85,24 @@ void recursive_list_test()//Test for recursive types
    }
 }
 
+template <class Iterator>
+bool test_value_init_iterator()
+{
+   // Create jumbled up memory to seat the iterator objects:
+   char c_arr[2*sizeof(Iterator)];
+   for(std::size_t i = 0; i < 2*sizeof(Iterator); ++i)
+      c_arr[i] = i;
+   Iterator* p_it1 = reinterpret_cast<Iterator*>(c_arr);
+   Iterator* p_it2 = reinterpret_cast<Iterator*>(c_arr + sizeof(Iterator));
+   // Do a placement value-initialization of iterators:
+   new(p_it1) Iterator();
+   new(p_it2) Iterator();
+   bool result = (*p_it1 == *p_it2);
+   p_it2->~Iterator();
+   p_it1->~Iterator();
+   return result;
+}
+
 template<class VoidAllocator>
 struct GetAllocatorCont
 {
@@ -202,6 +220,29 @@ int main ()
 
    if(!test_support_for_initializer_list())
       return 1;
+
+   ////////////////////////////////////
+   //    n3644 "Null forward iterator" test:
+   ////////////////////////////////////
+   { 
+      typedef list<int> cont_t;
+      if(!test_value_init_iterator<cont_t::iterator>()){
+         std::cerr << "test for n3644 failed on iterator on list" << std::endl;
+         return 1;
+      }
+      if(!test_value_init_iterator<cont_t::const_iterator>()){
+         std::cerr << "test for n3644 failed on const_iterator on list" << std::endl;
+         return 1;
+      }
+      if(!test_value_init_iterator<cont_t::reverse_iterator>()){
+         std::cerr << "test for n3644 failed on reverse_iterator on list" << std::endl;
+         return 1;
+      }
+      if(!test_value_init_iterator<cont_t::const_reverse_iterator>()){
+         std::cerr << "test for n3644 failed on const_reverse_iterator on list" << std::endl;
+         return 1;
+      }
+   }
 
    return 0;
 }

--- a/test/map_test.cpp
+++ b/test/map_test.cpp
@@ -234,6 +234,24 @@ void test_move()
    move_assign.swap(original);
 }
 
+template <class Iterator>
+bool test_value_init_iterator()
+{
+   // Create jumbled up memory to seat the iterator objects:
+   char c_arr[2*sizeof(Iterator)];
+   for(std::size_t i = 0; i < 2*sizeof(Iterator); ++i)
+      c_arr[i] = i;
+   Iterator* p_it1 = reinterpret_cast<Iterator*>(c_arr);
+   Iterator* p_it2 = reinterpret_cast<Iterator*>(c_arr + sizeof(Iterator));
+   // Do a placement value-initialization of iterators:
+   new(p_it1) Iterator();
+   new(p_it2) Iterator();
+   bool result = (*p_it1 == *p_it2);
+   p_it2->~Iterator();
+   p_it1->~Iterator();
+   return result;
+}
+
 template<class T, class A>
 class map_propagate_test_wrapper
    : public boost::container::map
@@ -469,6 +487,48 @@ int main ()
 
    if(!test_support_for_initialization_list_for<multimap<int, int> >())
       return 1;
+
+   ////////////////////////////////////
+   //    n3644 "Null forward iterator" test:
+   ////////////////////////////////////
+   { 
+      typedef map<int, int> cont_t;
+      if(!test_value_init_iterator<cont_t::iterator>()){
+         std::cerr << "test for n3644 failed on iterator on map" << std::endl;
+         return 1;
+      }
+      if(!test_value_init_iterator<cont_t::const_iterator>()){
+         std::cerr << "test for n3644 failed on const_iterator on map" << std::endl;
+         return 1;
+      }
+      if(!test_value_init_iterator<cont_t::reverse_iterator>()){
+         std::cerr << "test for n3644 failed on reverse_iterator on map" << std::endl;
+         return 1;
+      }
+      if(!test_value_init_iterator<cont_t::const_reverse_iterator>()){
+         std::cerr << "test for n3644 failed on const_reverse_iterator on map" << std::endl;
+         return 1;
+      }
+   }
+   {
+      typedef multimap<int, int> cont_t;
+      if(!test_value_init_iterator<cont_t::iterator>()){
+         std::cerr << "test for n3644 failed on iterator on multimap" << std::endl;
+         return 1;
+      }
+      if(!test_value_init_iterator<cont_t::const_iterator>()){
+         std::cerr << "test for n3644 failed on const_iterator on multimap" << std::endl;
+         return 1;
+      }
+      if(!test_value_init_iterator<cont_t::reverse_iterator>()){
+         std::cerr << "test for n3644 failed on reverse_iterator on multimap" << std::endl;
+         return 1;
+      }
+      if(!test_value_init_iterator<cont_t::const_reverse_iterator>()){
+         std::cerr << "test for n3644 failed on const_reverse_iterator on multimap" << std::endl;
+         return 1;
+      }
+   }
 
    ////////////////////////////////////
    //    Test optimize_size option

--- a/test/set_test.cpp
+++ b/test/set_test.cpp
@@ -212,6 +212,24 @@ void test_move()
    move_assign.swap(original);
 }
 
+template <class Iterator>
+bool test_value_init_iterator()
+{
+   // Create jumbled up memory to seat the iterator objects:
+   char c_arr[2*sizeof(Iterator)];
+   for(std::size_t i = 0; i < 2*sizeof(Iterator); ++i)
+      c_arr[i] = i;
+   Iterator* p_it1 = reinterpret_cast<Iterator*>(c_arr);
+   Iterator* p_it2 = reinterpret_cast<Iterator*>(c_arr + sizeof(Iterator));
+   // Do a placement value-initialization of iterators:
+   new(p_it1) Iterator();
+   new(p_it2) Iterator();
+   bool result = (*p_it1 == *p_it2);
+   p_it2->~Iterator();
+   p_it1->~Iterator();
+   return result;
+}
+
 template<class T, class A>
 class set_propagate_test_wrapper
    : public boost::container::set<T, std::less<T>, A
@@ -435,6 +453,48 @@ int main ()
 
    if(!test_support_for_initialization_list_for<multiset<int> >())
       return 1;
+
+   ////////////////////////////////////
+   //    n3644 "Null forward iterator" test:
+   ////////////////////////////////////
+   { 
+      typedef set<int> cont_t;
+      if(!test_value_init_iterator<cont_t::iterator>()){
+         std::cerr << "test for n3644 failed on iterator on set" << std::endl;
+         return 1;
+      }
+      if(!test_value_init_iterator<cont_t::const_iterator>()){
+         std::cerr << "test for n3644 failed on const_iterator on set" << std::endl;
+         return 1;
+      }
+      if(!test_value_init_iterator<cont_t::reverse_iterator>()){
+         std::cerr << "test for n3644 failed on reverse_iterator on set" << std::endl;
+         return 1;
+      }
+      if(!test_value_init_iterator<cont_t::const_reverse_iterator>()){
+         std::cerr << "test for n3644 failed on const_reverse_iterator on set" << std::endl;
+         return 1;
+      }
+   }
+   {
+      typedef multiset<int> cont_t;
+      if(!test_value_init_iterator<cont_t::iterator>()){
+         std::cerr << "test for n3644 failed on iterator on multiset" << std::endl;
+         return 1;
+      }
+      if(!test_value_init_iterator<cont_t::const_iterator>()){
+         std::cerr << "test for n3644 failed on const_iterator on multiset" << std::endl;
+         return 1;
+      }
+      if(!test_value_init_iterator<cont_t::reverse_iterator>()){
+         std::cerr << "test for n3644 failed on reverse_iterator on multiset" << std::endl;
+         return 1;
+      }
+      if(!test_value_init_iterator<cont_t::const_reverse_iterator>()){
+         std::cerr << "test for n3644 failed on const_reverse_iterator on multiset" << std::endl;
+         return 1;
+      }
+   }
 
    ////////////////////////////////////
    //    Test optimize_size option

--- a/test/slist_test.cpp
+++ b/test/slist_test.cpp
@@ -69,6 +69,24 @@ void recursive_slist_test()//Test for recursive types
    slist<recursive_slist> recursive_list_list;
 }
 
+template <class Iterator>
+bool test_value_init_iterator()
+{
+   // Create jumbled up memory to seat the iterator objects:
+   char c_arr[2*sizeof(Iterator)];
+   for(std::size_t i = 0; i < 2*sizeof(Iterator); ++i)
+      c_arr[i] = i;
+   Iterator* p_it1 = reinterpret_cast<Iterator*>(c_arr);
+   Iterator* p_it2 = reinterpret_cast<Iterator*>(c_arr + sizeof(Iterator));
+   // Do a placement value-initialization of iterators:
+   new(p_it1) Iterator();
+   new(p_it2) Iterator();
+   bool result = (*p_it1 == *p_it2);
+   p_it2->~Iterator();
+   p_it1->~Iterator();
+   return result;
+}
+
 template<class VoidAllocator>
 struct GetAllocatorCont
 {
@@ -207,6 +225,22 @@ int main ()
 
    if(!test_support_for_initializer_list())
       return 1;
+
+   ////////////////////////////////////
+   //    n3644 "Null forward iterator" test:
+   ////////////////////////////////////
+   { 
+      typedef slist<int> cont_t;
+      if(!test_value_init_iterator<cont_t::iterator>()){
+         std::cerr << "test for n3644 failed on iterator on slist" << std::endl;
+         return 1;
+      }
+      if(!test_value_init_iterator<cont_t::const_iterator>()){
+         std::cerr << "test for n3644 failed on const_iterator on slist" << std::endl;
+         return 1;
+      }
+   }
+
 }
 
 #include <boost/container/detail/config_end.hpp>

--- a/test/stable_vector_test.cpp
+++ b/test/stable_vector_test.cpp
@@ -84,6 +84,24 @@ void recursive_vector_test()//Test for recursive types
    }
 }
 
+template <class Iterator>
+bool test_value_init_iterator()
+{
+   // Create jumbled up memory to seat the iterator objects:
+   char c_arr[2*sizeof(Iterator)];
+   for(std::size_t i = 0; i < 2*sizeof(Iterator); ++i)
+      c_arr[i] = i;
+   Iterator* p_it1 = reinterpret_cast<Iterator*>(c_arr);
+   Iterator* p_it2 = reinterpret_cast<Iterator*>(c_arr + sizeof(Iterator));
+   // Do a placement value-initialization of iterators:
+   new(p_it1) Iterator();
+   new(p_it2) Iterator();
+   bool result = (*p_it1 == *p_it2);
+   p_it2->~Iterator();
+   p_it1->~Iterator();
+   return result;
+}
+
 template<class VoidAllocator>
 struct GetAllocatorCont
 {
@@ -192,6 +210,29 @@ int main()
    {
        std::cerr << "test_methods_with_initializer_list_as_argument failed" << std::endl;
        return 1;
+   }
+
+   ////////////////////////////////////
+   //    n3644 "Null forward iterator" test:
+   ////////////////////////////////////
+   { 
+      typedef stable_vector<int> cont_t;
+      if(!test_value_init_iterator<cont_t::iterator>()){
+         std::cerr << "test for n3644 failed on iterator on stable_vector" << std::endl;
+         return 1;
+      }
+      if(!test_value_init_iterator<cont_t::const_iterator>()){
+         std::cerr << "test for n3644 failed on const_iterator on stable_vector" << std::endl;
+         return 1;
+      }
+      if(!test_value_init_iterator<cont_t::reverse_iterator>()){
+         std::cerr << "test for n3644 failed on reverse_iterator on stable_vector" << std::endl;
+         return 1;
+      }
+      if(!test_value_init_iterator<cont_t::const_reverse_iterator>()){
+         std::cerr << "test for n3644 failed on const_reverse_iterator on stable_vector" << std::endl;
+         return 1;
+      }
    }
 
    return 0;

--- a/test/static_vector_test.cpp
+++ b/test/static_vector_test.cpp
@@ -689,6 +689,24 @@ bool default_init_test()//Test for default initialization
    return true;
 }
 
+template <class Iterator>
+bool test_value_init_iterator()
+{
+   // Create jumbled up memory to seat the iterator objects:
+   char c_arr[2*sizeof(Iterator)];
+   for(std::size_t i = 0; i < 2*sizeof(Iterator); ++i)
+      c_arr[i] = i;
+   Iterator* p_it1 = reinterpret_cast<Iterator*>(c_arr);
+   Iterator* p_it2 = reinterpret_cast<Iterator*>(c_arr + sizeof(Iterator));
+   // Do a placement value-initialization of iterators:
+   new(p_it1) Iterator();
+   new(p_it2) Iterator();
+   bool result = (*p_it1 == *p_it2);
+   p_it2->~Iterator();
+   p_it1->~Iterator();
+   return result;
+}
+
 
 int main(int, char* [])
 {
@@ -810,6 +828,29 @@ int main(int, char* [])
    BOOST_TEST(default_init_test() == true);
 
    test_support_for_initializer_list();
+
+   ////////////////////////////////////
+   //    n3644 "Null forward iterator" test:
+   ////////////////////////////////////
+   { 
+      typedef static_vector<int, 100> cont_t;
+      if(!test_value_init_iterator<cont_t::iterator>()){
+         std::cerr << "test for n3644 failed on iterator on static_vector" << std::endl;
+         return 1;
+      }
+      if(!test_value_init_iterator<cont_t::const_iterator>()){
+         std::cerr << "test for n3644 failed on const_iterator on static_vector" << std::endl;
+         return 1;
+      }
+      if(!test_value_init_iterator<cont_t::reverse_iterator>()){
+         std::cerr << "test for n3644 failed on reverse_iterator on static_vector" << std::endl;
+         return 1;
+      }
+      if(!test_value_init_iterator<cont_t::const_reverse_iterator>()){
+         std::cerr << "test for n3644 failed on const_reverse_iterator on static_vector" << std::endl;
+         return 1;
+      }
+   }
 
    return boost::report_errors();
 }

--- a/test/vector_test.cpp
+++ b/test/vector_test.cpp
@@ -123,6 +123,24 @@ void recursive_vector_test()//Test for recursive types
    vector<recursive_vector> recursive_vector_vector;
 }
 
+template <class Iterator>
+bool test_value_init_iterator()
+{
+   // Create jumbled up memory to seat the iterator objects:
+   char c_arr[2*sizeof(Iterator)];
+   for(std::size_t i = 0; i < 2*sizeof(Iterator); ++i)
+      c_arr[i] = i;
+   Iterator* p_it1 = reinterpret_cast<Iterator*>(c_arr);
+   Iterator* p_it2 = reinterpret_cast<Iterator*>(c_arr + sizeof(Iterator));
+   // Do a placement value-initialization of iterators:
+   new(p_it1) Iterator();
+   new(p_it2) Iterator();
+   bool result = (*p_it1 == *p_it2);
+   p_it2->~Iterator();
+   p_it1->~Iterator();
+   return result;
+}
+
 enum Test
 {
    zero, one, two, three, four, five, six
@@ -263,6 +281,30 @@ int main()
    >()) {
       return 1;
    }
+
+   ////////////////////////////////////
+   //    n3644 "Null forward iterator" test:
+   ////////////////////////////////////
+   { 
+      typedef vector<int> cont_t;
+      if(!test_value_init_iterator<cont_t::iterator>()){
+         std::cerr << "test for n3644 failed on iterator on vector" << std::endl;
+         return 1;
+      }
+      if(!test_value_init_iterator<cont_t::const_iterator>()){
+         std::cerr << "test for n3644 failed on const_iterator on vector" << std::endl;
+         return 1;
+      }
+      if(!test_value_init_iterator<cont_t::reverse_iterator>()){
+         std::cerr << "test for n3644 failed on reverse_iterator on vector" << std::endl;
+         return 1;
+      }
+      if(!test_value_init_iterator<cont_t::const_reverse_iterator>()){
+         std::cerr << "test for n3644 failed on const_reverse_iterator on vector" << std::endl;
+         return 1;
+      }
+   }
+
    return 0;
 
 }


### PR DESCRIPTION
Updated vector and stable-vector iterators for n3644 compliance.
Added n3644 compliance tests to all container iterators.

Boost.Intrusive commit needed too (maybe more are needed there too, if all intrusive containers are going to comply to n3644 too).
