### PR TITLE
PR8175: Use std::allocator_arg_t

### DIFF
--- a/include/boost/container/scoped_allocator_fwd.hpp
+++ b/include/boost/container/scoped_allocator_fwd.hpp
@@ -27,6 +27,10 @@
 #include <boost/container/detail/type_traits.hpp>
 #endif
 
+#if __cplusplus >= 201103L
+#include <memory>
+#endif
+
 namespace boost { namespace container {
 
 #ifndef BOOST_CONTAINER_DOXYGEN_INVOKED
@@ -65,7 +69,11 @@ class scoped_allocator_adaptor;
 //! disambiguate constructor and function overloading. Specifically, several types
 //! have constructors with allocator_arg_t as the first argument, immediately followed
 //! by an argument of a type that satisfies the Allocator requirements
+#if __cplusplus < 201103L
 struct allocator_arg_t{};
+#else
+using allocator_arg_t = std::allocator_arg_t;
+#endif
 
 //! A instance of type allocator_arg_t
 //!


### PR DESCRIPTION
Use std::allocator_arg_t when c++11 is available instead of own allocator_arg_t
