### PR TITLE
Remove predefines that are breaking the doxygen build.

### DIFF
--- a/doc/Jamfile.v2
+++ b/doc/Jamfile.v2
@@ -41,8 +41,6 @@ doxygen autodoc
                                    \"BOOST_CONTAINER_DOC1ST(T1, T2)=T1\" \\
                                    \"BOOST_CONTAINER_DOCIGN(T) \"\\
                                    \"BOOST_CONTAINER_DOCONLY(T) T\"\\
-                                   \"BOOST_CONTAINER_SCOPEDALLOC_DUMMYTRUE=\"\\
-                                   \"BOOST_CONTAINER_SCOPEDALLOC_ALLINNER=InnerAllocs...\"\\
                                    "
         <xsl:param>"boost.doxygen.reftitle=Boost.Container Header Reference"
    ;


### PR DESCRIPTION
I have no idea why they're breaking the build, but the macros appear to be defined in the appropriate header, so maybe they're not needed anyway?

Btw. to replicate the failure you need to delete the temporary files under bin.v2, as boost.build doesn't detect the failure, and will continue with the old copies from the last successful build. I'm using doxygen 1.8.8, maybe this is fixed in later versions?