### PR TITLE
Fix bug in stable_vector::capacity()

### DIFF
--- a/include/boost/container/stable_vector.hpp
+++ b/include/boost/container/stable_vector.hpp
@@ -1117,7 +1117,7 @@ class stable_vector
       const size_type extra_capacity        = (bucket_extra_capacity < node_extra_capacity)
          ? bucket_extra_capacity : node_extra_capacity;
       const size_type index_offset =
-         (ExtraPointers + extra_capacity) & (size_type(0u) - size_type(index_size != 0));
+         (ExtraPointers - extra_capacity) & (size_type(0u) - size_type(index_size != 0));
       return index_size - index_offset;
    }
 


### PR DESCRIPTION
See http://stackoverflow.com/q/29727368/2756719; the bit-twiddling version is not equivalent to the original `return (index_size ? (index_size - ExtraPointers + extra_capacity) : index_size);`; it ends up subtracting, rather than adding, extra_capacity.