### PR TITLE
Fix std:: forward declaration compile error on GCC with libc++

### DIFF
--- a/include/boost/container/detail/std_fwd.hpp
+++ b/include/boost/container/detail/std_fwd.hpp
@@ -23,10 +23,12 @@
 //                        Standard predeclarations
 //////////////////////////////////////////////////////////////////////////////
 
-#if defined(__clang__) && defined(_LIBCPP_VERSION)
+#if defined(_LIBCPP_VERSION)
    #define BOOST_CONTAINER_CLANG_INLINE_STD_NS
    #pragma GCC diagnostic push
+#if defined(__clang__)
    #pragma GCC diagnostic ignored "-Wc++11-extensions"
+#endif
    #define BOOST_CONTAINER_STD_NS_BEG _LIBCPP_BEGIN_NAMESPACE_STD
    #define BOOST_CONTAINER_STD_NS_END _LIBCPP_END_NAMESPACE_STD
 #elif defined(BOOST_GNU_STDLIB) && defined(_GLIBCXX_BEGIN_NAMESPACE_VERSION)  //GCC >= 4.6


### PR DESCRIPTION
The code should not assume that libc++ is only ever used with Clang.

Fixes issue #11380, https://svn.boost.org/trac/boost/ticket/11380