### PR TITLE
Remove use of deprecated macros; use replacements

### DIFF
--- a/bench/detail/varray.hpp
+++ b/bench/detail/varray.hpp
@@ -235,7 +235,7 @@ class varray
 
     BOOST_COPYABLE_AND_MOVABLE(varray)
 
-#ifdef BOOST_NO_RVALUE_REFERENCES
+#ifdef BOOST_NO_CXX11_RVALUE_REFERENCES
 public:
     template <std::size_t C, typename S>
     varray & operator=(varray<Value, C, S> & sv)
@@ -422,7 +422,7 @@ public:
     //!   Linear O(N).
     template <std::size_t C, typename S>
 // TEMPORARY WORKAROUND
-#if defined(BOOST_NO_RVALUE_REFERENCES)
+#if defined(BOOST_NO_CXX11_RVALUE_REFERENCES)
     varray & operator=(::boost::rv< varray<value_type, C, S> > const& other)
 #else
     varray & operator=(varray<value_type, C, S> const& other)

--- a/bench/detail/varray_util.hpp
+++ b/bench/detail/varray_util.hpp
@@ -537,8 +537,8 @@ void construct(DisableTrivialInit const&,
 
 #else // !BOOST_NO_CXX11_VARIADIC_TEMPLATES
 
-// BOOST_NO_RVALUE_REFERENCES -> P0 const& p0
-// !BOOST_NO_RVALUE_REFERENCES -> P0 && p0
+// BOOST_NO_CXX11_RVALUE_REFERENCES -> P0 const& p0
+// !BOOST_NO_CXX11_RVALUE_REFERENCES -> P0 && p0
 // which means that version with one parameter may take V const& v
 
 #define BOOST_CONTAINER_VARRAY_UTIL_CONSTRUCT_CODE(N) \

--- a/bench/varray.hpp
+++ b/bench/varray.hpp
@@ -200,7 +200,7 @@ public:
     //!   Linear O(N).
     template <std::size_t C>
 // TEMPORARY WORKAROUND
-#if defined(BOOST_NO_RVALUE_REFERENCES)
+#if defined(BOOST_NO_CXX11_RVALUE_REFERENCES)
     varray & operator=(::boost::rv< varray<value_type, C> > const& other)
 #else
     varray & operator=(varray<value_type, C> const& other)


### PR DESCRIPTION
The macro `BOOST_NO_RVALUE_REFERENCES` was deprecated in boost 1.51.0, and was replaced by `BOOST_NO_CXX11_RVALUE_REFERENCES`.  It's been 8 releases since these were deprecated, and I'd like to remove them

Replace all uses of `BOOST_NO_RVALUE_REFERENCES` with `BOOST_NO_CXX11_RVALUE_REFERENCES`. 

No functionality change.