### PR TITLE
Add check for segment_holding() failure

### DIFF
--- a/doc/container.qbk
+++ b/doc/container.qbk
@@ -1223,6 +1223,7 @@ use [*Boost.Container]? There are several reasons for that:
    * [@https://svn.boost.org/trac/boost/ticket/11628 Trac #11628: ['"small_vector<int,n> iterates over elements in destructor"]].
    * [@https://svn.boost.org/trac/boost/ticket/11697 Trac #11697: ['"Wrong initialization order in tuple copy-constructor"]].
    * [@https://svn.boost.org/trac/boost/ticket/11698 Trac #11698: ['"Missing return statement in static_storage_allocator"]].
+   * [@https://github.com/boostorg/container/pull/32 GitHub #32: ['Add check for segment_holding() failure]].
 
 [endsect]
 

--- a/src/dlmalloc_2_8_6.c
+++ b/src/dlmalloc_2_8_6.c
@@ -4300,6 +4300,7 @@ static int sys_trim(mstate m, size_t pad) {
       size_t extra = ((m->topsize - pad + (unit - SIZE_T_ONE)) / unit -
                       SIZE_T_ONE) * unit;
       msegmentptr sp = segment_holding(m, (char*)m->top);
+      assert(sp);
 
       if (!is_extern_segment(sp)) {
         if (is_mmapped_segment(sp)) {

--- a/src/dlmalloc_2_8_6.c
+++ b/src/dlmalloc_2_8_6.c
@@ -3978,6 +3978,7 @@ static void add_segment(mstate m, char* tbase, size_t tsize, flag_t mmapped) {
   /* Determine locations and sizes of segment, fenceposts, old top */
   char* old_top = (char*)m->top;
   msegmentptr oldsp = segment_holding(m, old_top);
+  assert(oldsp);
   char* old_end = oldsp->base + oldsp->size;
   size_t ssize = pad_request(sizeof(struct malloc_segment));
   char* rawsp = old_end - (ssize + FOUR_SIZE_T_SIZES + CHUNK_ALIGN_MASK);


### PR DESCRIPTION
segment_holding can return 0, in that case dereferencing oldsp will cause crash.
assert added for Null return.
