### PR TITLE
Make sure std::string constructor is available

### DIFF
--- a/include/boost/container/throw_exception.hpp
+++ b/include/boost/container/throw_exception.hpp
@@ -24,6 +24,7 @@
 
 #ifndef BOOST_NO_EXCEPTIONS
    #include <stdexcept> //for std exception types
+   #include <string>    //for implicit std::string conversion
    #include <new>       //for std::bad_alloc
 #else
    #include <boost/assert.hpp>


### PR DESCRIPTION
Make sure `std::string` constructor is available because `<stdexcept>` only needs to have a forward declaration of `std::string`. But that's not enough to invoke constructors of `std::exception` (and derivatives) if we don't have a reference to an `std::string` handy.

This is necessary with STLport which only includes a forward declaration of `std::string` in `<stdexcept>`.