### PR TITLE
Allow reuse of buffer in reserve with v2 allocator

### DIFF
--- a/include/boost/container/vector.hpp
+++ b/include/boost/container/vector.hpp
@@ -2543,7 +2543,7 @@ class vector
       //buffer or expand the old one.
       bool same_buffer_start;
       size_type real_cap = 0;
-      pointer reuse = 0;
+      pointer reuse(this->m_holder.start());
       pointer const ret(this->m_holder.allocation_command(allocate_new | expand_fwd | expand_bwd, new_cap, real_cap = new_cap, reuse));
 
       //Check for forward expansion


### PR DESCRIPTION
allocation_command uses expand_{fwd,bwd} flags and its result is later compared with the old pointer, but the old pointer was not passed for reuse.