### PR TITLE
Fix parameter type of uninitialized_copy_alloc_n_source()

### DIFF
--- a/include/boost/container/detail/copy_move_algo.hpp
+++ b/include/boost/container/detail/copy_move_algo.hpp
@@ -512,7 +512,7 @@ template
     typename I, // I models InputIterator
     typename F> // F models ForwardIterator
 inline typename container_detail::disable_if_memtransfer_copy_constructible<I, F, I>::type
-   uninitialized_copy_alloc_n_source(Allocator &a, I f, typename boost::container::iterator_traits<I>::difference_type n, F r)
+   uninitialized_copy_alloc_n_source(Allocator &a, I f, typename boost::container::allocator_traits<Allocator>::size_type n, F r)
 {
    F back = r;
    BOOST_TRY{


### PR DESCRIPTION
This function constructs n objects using Allocator, so the number of objects should be given as the (unsigned) allocator_traits<Allocator>::size_type. There are two callers, both of which already use size_type. However, the function signature did not reflect this yet. This fix makes the function signature compatible with the callers.