### PR TITLE
Fix parameter types in copy_move_algo.hpp: iterator_traits::difference_type -> allocator_traits::size_type

### DIFF
--- a/include/boost/container/detail/copy_move_algo.hpp
+++ b/include/boost/container/detail/copy_move_algo.hpp
@@ -512,7 +512,7 @@ template
     typename I, // I models InputIterator
     typename F> // F models ForwardIterator
 inline typename container_detail::disable_if_memtransfer_copy_constructible<I, F, I>::type
-   uninitialized_copy_alloc_n_source(Allocator &a, I f, typename boost::container::iterator_traits<I>::difference_type n, F r)
+   uninitialized_copy_alloc_n_source(Allocator &a, I f, typename boost::container::allocator_traits<Allocator>::size_type n, F r)
 {
    F back = r;
    BOOST_TRY{

--- a/include/boost/container/detail/copy_move_algo.hpp
+++ b/include/boost/container/detail/copy_move_algo.hpp
@@ -186,8 +186,9 @@ inline F memmove(I f, I l, F r) BOOST_NOEXCEPT_OR_NOTHROW
 
 template
    <typename I, // I models InputIterator
+    typename U, // U models unsigned integral constant
     typename F> // F models ForwardIterator
-F memmove_n(I f, typename boost::container::iterator_traits<I>::difference_type n, F r) BOOST_NOEXCEPT_OR_NOTHROW
+F memmove_n(I f, U n, F r) BOOST_NOEXCEPT_OR_NOTHROW
 {
    typedef typename boost::container::iterator_traits<I>::value_type value_type;
    if(n){
@@ -199,8 +200,9 @@ F memmove_n(I f, typename boost::container::iterator_traits<I>::difference_type 
 
 template
    <typename I, // I models InputIterator
+    typename U, // U models unsigned integral constant
     typename F> // F models ForwardIterator
-I memmove_n_source(I f, typename boost::container::iterator_traits<I>::difference_type n, F r) BOOST_NOEXCEPT_OR_NOTHROW
+I memmove_n_source(I f, U n, F r) BOOST_NOEXCEPT_OR_NOTHROW
 {
    if(n){
       typedef typename boost::container::iterator_traits<I>::value_type value_type;
@@ -212,8 +214,9 @@ I memmove_n_source(I f, typename boost::container::iterator_traits<I>::differenc
 
 template
    <typename I, // I models InputIterator
+    typename U, // U models unsigned integral constant
     typename F> // F models ForwardIterator
-I memmove_n_source_dest(I f, typename boost::container::iterator_traits<I>::difference_type n, F &r) BOOST_NOEXCEPT_OR_NOTHROW
+I memmove_n_source_dest(I f, U n, F &r) BOOST_NOEXCEPT_OR_NOTHROW
 {
    typedef typename boost::container::iterator_traits<I>::value_type value_type;
    if(n){
@@ -332,7 +335,7 @@ template
     typename I, // I models InputIterator
     typename F> // F models ForwardIterator
 inline typename container_detail::disable_if_memtransfer_copy_constructible<I, F, F>::type
-   uninitialized_move_alloc_n(Allocator &a, I f, typename boost::container::iterator_traits<I>::difference_type n, F r)
+   uninitialized_move_alloc_n(Allocator &a, I f, typename boost::container::allocator_traits<Allocator>::size_type n, F r)
 {
    F back = r;
    BOOST_TRY{
@@ -356,7 +359,7 @@ template
     typename I, // I models InputIterator
     typename F> // F models ForwardIterator
 inline typename container_detail::enable_if_memtransfer_copy_constructible<I, F, F>::type
-   uninitialized_move_alloc_n(Allocator &, I f, typename boost::container::iterator_traits<I>::difference_type n, F r) BOOST_NOEXCEPT_OR_NOTHROW
+   uninitialized_move_alloc_n(Allocator &, I f, typename boost::container::allocator_traits<Allocator>::size_type n, F r) BOOST_NOEXCEPT_OR_NOTHROW
 {  return container_detail::memmove_n(f, n, r); }
 
 //////////////////////////////////////////////////////////////////////////////
@@ -377,7 +380,7 @@ template
     typename I, // I models InputIterator
     typename F> // F models ForwardIterator
 inline typename container_detail::disable_if_memtransfer_copy_constructible<I, F, I>::type
-   uninitialized_move_alloc_n_source(Allocator &a, I f, typename boost::container::iterator_traits<I>::difference_type n, F r)
+   uninitialized_move_alloc_n_source(Allocator &a, I f, typename boost::container::allocator_traits<Allocator>::size_type n, F r)
 {
    F back = r;
    BOOST_TRY{
@@ -401,7 +404,7 @@ template
     typename I, // I models InputIterator
     typename F> // F models ForwardIterator
 inline typename container_detail::enable_if_memtransfer_copy_constructible<I, F, I>::type
-   uninitialized_move_alloc_n_source(Allocator &, I f, typename boost::container::iterator_traits<I>::difference_type n, F r) BOOST_NOEXCEPT_OR_NOTHROW
+   uninitialized_move_alloc_n_source(Allocator &, I f, typename boost::container::allocator_traits<Allocator>::size_type n, F r) BOOST_NOEXCEPT_OR_NOTHROW
 {  return container_detail::memmove_n_source(f, n, r); }
 
 //////////////////////////////////////////////////////////////////////////////
@@ -467,7 +470,7 @@ template
     typename I, // I models InputIterator
     typename F> // F models ForwardIterator
 inline typename container_detail::disable_if_memtransfer_copy_constructible<I, F, F>::type
-   uninitialized_copy_alloc_n(Allocator &a, I f, typename boost::container::iterator_traits<I>::difference_type n, F r)
+   uninitialized_copy_alloc_n(Allocator &a, I f, typename boost::container::allocator_traits<Allocator>::size_type n, F r)
 {
    F back = r;
    BOOST_TRY{
@@ -491,7 +494,7 @@ template
     typename I, // I models InputIterator
     typename F> // F models ForwardIterator
 inline typename container_detail::enable_if_memtransfer_copy_constructible<I, F, F>::type
-   uninitialized_copy_alloc_n(Allocator &, I f, typename boost::container::iterator_traits<I>::difference_type n, F r) BOOST_NOEXCEPT_OR_NOTHROW
+   uninitialized_copy_alloc_n(Allocator &, I f, typename boost::container::allocator_traits<Allocator>::size_type n, F r) BOOST_NOEXCEPT_OR_NOTHROW
 {  return container_detail::memmove_n(f, n, r); }
 
 //////////////////////////////////////////////////////////////////////////////
@@ -536,7 +539,7 @@ template
     typename I, // I models InputIterator
     typename F> // F models ForwardIterator
 inline typename container_detail::enable_if_memtransfer_copy_constructible<I, F, I>::type
-   uninitialized_copy_alloc_n_source(Allocator &, I f, typename boost::container::iterator_traits<I>::difference_type n, F r) BOOST_NOEXCEPT_OR_NOTHROW
+   uninitialized_copy_alloc_n_source(Allocator &, I f, typename boost::container::allocator_traits<Allocator>::size_type n, F r) BOOST_NOEXCEPT_OR_NOTHROW
 {  return container_detail::memmove_n_source(f, n, r); }
 
 //////////////////////////////////////////////////////////////////////////////
@@ -556,7 +559,7 @@ template
    <typename Allocator,
     typename F> // F models ForwardIterator
 inline typename container_detail::disable_if_memzero_initializable<F, F>::type
-   uninitialized_value_init_alloc_n(Allocator &a, typename allocator_traits<Allocator>::difference_type n, F r)
+   uninitialized_value_init_alloc_n(Allocator &a, typename boost::container::allocator_traits<Allocator>::size_type n, F r)
 {
    F back = r;
    BOOST_TRY{
@@ -579,7 +582,7 @@ template
    <typename Allocator,
     typename F> // F models ForwardIterator
 inline typename container_detail::enable_if_memzero_initializable<F, F>::type
-   uninitialized_value_init_alloc_n(Allocator &, typename allocator_traits<Allocator>::difference_type n, F r)
+   uninitialized_value_init_alloc_n(Allocator &, typename boost::container::allocator_traits<Allocator>::size_type n, F r)
 {
    typedef typename boost::container::iterator_traits<F>::value_type value_type;
    std::memset((void*)container_detail::iterator_to_raw_pointer(r), 0, sizeof(value_type)*n);
@@ -603,7 +606,7 @@ inline typename container_detail::enable_if_memzero_initializable<F, F>::type
 template
    <typename Allocator,
     typename F> // F models ForwardIterator
-inline F uninitialized_default_init_alloc_n(Allocator &a, typename allocator_traits<Allocator>::difference_type n, F r)
+inline F uninitialized_default_init_alloc_n(Allocator &a, typename boost::container::allocator_traits<Allocator>::size_type n, F r)
 {
    F back = r;
    BOOST_TRY{
@@ -675,7 +678,7 @@ template
    <typename Allocator,
     typename T,
     typename F> // F models ForwardIterator
-inline F uninitialized_fill_alloc_n(Allocator &a, const T &v, typename allocator_traits<Allocator>::difference_type n, F r)
+inline F uninitialized_fill_alloc_n(Allocator &a, const T &v, typename boost::container::allocator_traits<Allocator>::size_type n, F r)
 {
    F back = r;
    BOOST_TRY{
@@ -728,9 +731,10 @@ inline typename container_detail::enable_if_memtransfer_copy_assignable<I, F, F>
 
 template
 <typename I,   // I models InputIterator
+typename U,   // U models unsigned integral constant
 typename F>   // F models ForwardIterator
 inline typename container_detail::disable_if_memtransfer_copy_assignable<I, F, F>::type
-   copy_n(I f, typename boost::container::iterator_traits<I>::difference_type n, F r)
+   copy_n(I f, U n, F r)
 {
    while (n--) {
       *r = *f;
@@ -741,9 +745,10 @@ inline typename container_detail::disable_if_memtransfer_copy_assignable<I, F, F
 
 template
 <typename I,   // I models InputIterator
+typename U,   // U models unsigned integral constant
 typename F>   // F models ForwardIterator
 inline typename container_detail::enable_if_memtransfer_copy_assignable<I, F, F>::type
-   copy_n(I f, typename boost::container::iterator_traits<I>::difference_type n, F r) BOOST_NOEXCEPT_OR_NOTHROW
+   copy_n(I f, U n, F r) BOOST_NOEXCEPT_OR_NOTHROW
 {  return container_detail::memmove_n(f, n, r); }
 
 //////////////////////////////////////////////////////////////////////////////
@@ -754,9 +759,10 @@ inline typename container_detail::enable_if_memtransfer_copy_assignable<I, F, F>
 
 template
 <typename I,   // I models InputIterator
+typename U,   // U models unsigned integral constant
 typename F>   // F models ForwardIterator
 inline typename container_detail::disable_if_memtransfer_copy_assignable<I, F, I>::type
-   copy_n_source(I f, typename boost::container::iterator_traits<I>::difference_type n, F r)
+   copy_n_source(I f, U n, F r)
 {
    while (n--) {
       boost::container::assign_in_place(r, f);
@@ -767,9 +773,10 @@ inline typename container_detail::disable_if_memtransfer_copy_assignable<I, F, I
 
 template
 <typename I,   // I models InputIterator
+typename U,   // U models unsigned integral constant
 typename F>   // F models ForwardIterator
 inline typename container_detail::enable_if_memtransfer_copy_assignable<I, F, I>::type
-   copy_n_source(I f, typename boost::container::iterator_traits<I>::difference_type n, F r) BOOST_NOEXCEPT_OR_NOTHROW
+   copy_n_source(I f, U n, F r) BOOST_NOEXCEPT_OR_NOTHROW
 {  return container_detail::memmove_n_source(f, n, r); }
 
 //////////////////////////////////////////////////////////////////////////////
@@ -780,9 +787,10 @@ inline typename container_detail::enable_if_memtransfer_copy_assignable<I, F, I>
 
 template
 <typename I,   // I models InputIterator
+typename U,   // U models unsigned integral constant
 typename F>   // F models ForwardIterator
 inline typename container_detail::disable_if_memtransfer_copy_assignable<I, F, I>::type
-   copy_n_source_dest(I f, typename boost::container::iterator_traits<I>::difference_type n, F &r)
+   copy_n_source_dest(I f, U n, F &r)
 {
    while (n--) {
       *r = *f;
@@ -793,9 +801,10 @@ inline typename container_detail::disable_if_memtransfer_copy_assignable<I, F, I
 
 template
 <typename I,   // I models InputIterator
+typename U,   // U models unsigned integral constant
 typename F>   // F models ForwardIterator
 inline typename container_detail::enable_if_memtransfer_copy_assignable<I, F, I>::type
-   copy_n_source_dest(I f, typename boost::container::iterator_traits<I>::difference_type n, F &r) BOOST_NOEXCEPT_OR_NOTHROW
+   copy_n_source_dest(I f, U n, F &r) BOOST_NOEXCEPT_OR_NOTHROW
 {  return container_detail::memmove_n_source_dest(f, n, r);  }
 
 //////////////////////////////////////////////////////////////////////////////
@@ -832,9 +841,10 @@ inline typename container_detail::enable_if_memtransfer_copy_assignable<I, F, F>
 
 template
 <typename I,   // I models InputIterator
+typename U,   // U models unsigned integral constant
 typename F>   // F models ForwardIterator
 inline typename container_detail::disable_if_memtransfer_copy_assignable<I, F, F>::type
-   move_n(I f, typename boost::container::iterator_traits<I>::difference_type n, F r)
+   move_n(I f, U n, F r)
 {
    while (n--) {
       *r = ::boost::move(*f);
@@ -845,9 +855,10 @@ inline typename container_detail::disable_if_memtransfer_copy_assignable<I, F, F
 
 template
 <typename I,   // I models InputIterator
+typename U,   // U models unsigned integral constant
 typename F>   // F models ForwardIterator
 inline typename container_detail::enable_if_memtransfer_copy_assignable<I, F, F>::type
-   move_n(I f, typename boost::container::iterator_traits<I>::difference_type n, F r) BOOST_NOEXCEPT_OR_NOTHROW
+   move_n(I f, U n, F r) BOOST_NOEXCEPT_OR_NOTHROW
 {  return container_detail::memmove_n(f, n, r); }
 
 
@@ -891,9 +902,10 @@ inline typename container_detail::enable_if_memtransfer_copy_assignable<I, F, F>
 
 template
 <typename I    // I models InputIterator
+,typename U    // U models unsigned integral constant
 ,typename F>   // F models ForwardIterator
 inline typename container_detail::disable_if_memtransfer_copy_assignable<I, F, I>::type
-   move_n_source_dest(I f, typename boost::container::iterator_traits<I>::difference_type n, F &r)
+   move_n_source_dest(I f, U n, F &r)
 {
    while (n--) {
       *r = ::boost::move(*f);
@@ -904,9 +916,10 @@ inline typename container_detail::disable_if_memtransfer_copy_assignable<I, F, I
 
 template
 <typename I    // I models InputIterator
+,typename U    // U models unsigned integral constant
 ,typename F>   // F models ForwardIterator
 inline typename container_detail::enable_if_memtransfer_copy_assignable<I, F, I>::type
-   move_n_source_dest(I f, typename boost::container::iterator_traits<I>::difference_type n, F &r) BOOST_NOEXCEPT_OR_NOTHROW
+   move_n_source_dest(I f, U n, F &r) BOOST_NOEXCEPT_OR_NOTHROW
 {  return container_detail::memmove_n_source_dest(f, n, r); }
 
 //////////////////////////////////////////////////////////////////////////////
@@ -917,9 +930,10 @@ inline typename container_detail::enable_if_memtransfer_copy_assignable<I, F, I>
 
 template
 <typename I    // I models InputIterator
+,typename U    // U models unsigned integral constant
 ,typename F>   // F models ForwardIterator
 inline typename container_detail::disable_if_memtransfer_copy_assignable<I, F, I>::type
-   move_n_source(I f, typename boost::container::iterator_traits<I>::difference_type n, F r)
+   move_n_source(I f, U n, F r)
 {
    while (n--) {
       *r = ::boost::move(*f);
@@ -930,9 +944,10 @@ inline typename container_detail::disable_if_memtransfer_copy_assignable<I, F, I
 
 template
 <typename I    // I models InputIterator
+,typename U    // U models unsigned integral constant
 ,typename F>   // F models ForwardIterator
 inline typename container_detail::enable_if_memtransfer_copy_assignable<I, F, I>::type
-   move_n_source(I f, typename boost::container::iterator_traits<I>::difference_type n, F r) BOOST_NOEXCEPT_OR_NOTHROW
+   move_n_source(I f, U n, F r) BOOST_NOEXCEPT_OR_NOTHROW
 {  return container_detail::memmove_n_source(f, n, r); }
 
 //////////////////////////////////////////////////////////////////////////////

--- a/include/boost/container/vector.hpp
+++ b/include/boost/container/vector.hpp
@@ -3120,7 +3120,7 @@ class vector
             }
             else{ //If trivial destructor, we can uninitialized copy + copy in a single uninitialized copy
                ::boost::container::uninitialized_move_alloc_n
-                  (this->m_holder.alloc(), pos, old_finish - pos, new_start + before_plus_new);
+                  (this->m_holder.alloc(), pos, static_cast<size_type>(old_finish - pos), new_start + before_plus_new);
                this->m_holder.m_size = new_size;
                old_values_destroyer.release();
             }


### PR DESCRIPTION
Many of the functions inside copy_move_algo.hpp construct n objects using a specified Allocator, so the number of objects should be given as allocator_traits::size_type. The callers of these functions already use size_type, which currently leads to type conflicts if the InputIterator's difference_type is incompatible (e.g., smaller). 

There is one exception in vector.hpp, where uninitialized_move_alloc_n() is called with a raw pointer difference. I static_casted this to size_type for compatibility.

There are several remaining functions inside copy_move_algo.hpp that use a difference_type parameter, but are independent of an allocator. I changed these to be agnostic of the integral type, as was already done with destroy_alloc_n(). (In fact, all of these functions eventually get called with allocator_traits::size_type arguments.)
