### PR TITLE
[inspection report] remove tabs and fix copyright notice format

### DIFF
--- a/bench/bench_static_vector.cpp
+++ b/bench/bench_static_vector.cpp
@@ -4,8 +4,8 @@
 //  @date   Aug 14, 2011
 //  @author Andrew Hundt <ATHundt@gmail.com>
 //
-//  (C) 2011-2013 Andrew Hundt <ATHundt@gmail.com>
-//  (C) 2013-2013 Ion Gaztanaga
+//  (C) Copyright 2011-2013 Andrew Hundt <ATHundt@gmail.com>
+//  (C) Copyright 2013-2013 Ion Gaztanaga
 //
 //  Distributed under the Boost Software License, Version 1.0. (See
 //  accompanying file LICENSE_1_0.txt or copy at

--- a/include/boost/container/detail/advanced_insert_int.hpp
+++ b/include/boost/container/detail/advanced_insert_int.hpp
@@ -107,8 +107,8 @@ struct insert_n_copies_proxy
 
    void copy_n_and_update(Allocator &, Iterator p, size_type n) const
    {
-	   for (; 0 < n; --n, ++p){
-		   *p = v_;
+      for (; 0 < n; --n, ++p){
+         *p = v_;
       }
    }
 

--- a/include/boost/container/new_allocator.hpp
+++ b/include/boost/container/new_allocator.hpp
@@ -140,9 +140,9 @@ class new_allocator
    //!Throws std::bad_alloc if there is no enough memory
    pointer allocate(size_type count)
    {
-	   if(BOOST_UNLIKELY(count > this->max_size()))
-	      throw_bad_alloc();
-	   return static_cast<T*>(::operator new(count*sizeof(T)));
+      if(BOOST_UNLIKELY(count > this->max_size()))
+         throw_bad_alloc();
+      return static_cast<T*>(::operator new(count*sizeof(T)));
    }
 
    //!Deallocates previously allocated memory.

--- a/include/boost/container/small_vector.hpp
+++ b/include/boost/container/small_vector.hpp
@@ -507,7 +507,7 @@ class small_vector : public small_vector_base<T, Allocator>
 
    public:
    BOOST_CONTAINER_FORCEINLINE small_vector()
-	   BOOST_NOEXCEPT_IF(container_detail::is_nothrow_default_constructible<Allocator>::value)
+      BOOST_NOEXCEPT_IF(container_detail::is_nothrow_default_constructible<Allocator>::value)
       : base_type(initial_capacity_t(), internal_capacity())
    {}
 

--- a/test/map_test.cpp
+++ b/test/map_test.cpp
@@ -391,10 +391,10 @@ int main ()
    //Test std::pair value type as tree has workarounds to make old std::pair
    //implementations movable that can break things
    {
-	   boost::container::map<pair_t, pair_t> s;
-	   std::pair<const pair_t,pair_t> p;
-	   s.insert(p);
-	   s.emplace(p);
+      boost::container::map<pair_t, pair_t> s;
+      std::pair<const pair_t,pair_t> p;
+      s.insert(p);
+      s.emplace(p);
    }
 
    ////////////////////////////////////

--- a/test/set_test.cpp
+++ b/test/set_test.cpp
@@ -379,10 +379,10 @@ int main ()
    //Test std::pair value type as tree has workarounds to make old std::pair
    //implementations movable that can break things
    {
-	   boost::container::set<std::pair<int,int> > s;
-	   std::pair<int,int> p(0, 0);
-	   s.insert(p);
-	   s.emplace(p);
+      boost::container::set<std::pair<int,int> > s;
+      std::pair<int,int> p(0, 0);
+      s.insert(p);
+      s.emplace(p);
    }
 
    test_merge_from_different_comparison();


### PR DESCRIPTION
I added "Copyright" to `bench_static_vector.cpp` just to make the inspection tool happy.