### PR TITLE
added alignment specification for small_vector

### DIFF
--- a/include/boost/container/allocator_traits.hpp
+++ b/include/boost/container/allocator_traits.hpp
@@ -77,7 +77,7 @@ namespace container {
 
 #ifndef BOOST_CONTAINER_DOXYGEN_INVOKED
 
-template<class Allocator>
+template<class Allocator, std::size_t alignment>
 class small_vector_allocator;
 
 namespace allocator_traits_detail {
@@ -100,7 +100,7 @@ struct is_std_allocator< std::allocator<T> >
 {  static const bool value = true; };
 
 template<class T>
-struct is_std_allocator< small_vector_allocator< std::allocator<T> > >
+struct is_std_allocator< small_vector_allocator< std::allocator<T>, 0 > >
 {  static const bool value = true; };
 
 template<class Allocator>
@@ -289,18 +289,18 @@ struct allocator_traits
 
    //! <b>Returns</b>: <code>a.allocate(n)</code>
    //!
-   BOOST_CONTAINER_FORCEINLINE static pointer allocate(Allocator &a, size_type n)
+   static pointer allocate(Allocator &a, size_type n)
    {  return a.allocate(n);  }
 
    //! <b>Returns</b>: <code>a.deallocate(p, n)</code>
    //!
    //! <b>Throws</b>: Nothing
-   BOOST_CONTAINER_FORCEINLINE static void deallocate(Allocator &a, pointer p, size_type n)
+   static void deallocate(Allocator &a, pointer p, size_type n)
    {  a.deallocate(p, n);  }
 
    //! <b>Effects</b>: calls <code>a.allocate(n, p)</code> if that call is well-formed;
    //! otherwise, invokes <code>a.allocate(n)</code>
-   BOOST_CONTAINER_FORCEINLINE static pointer allocate(Allocator &a, size_type n, const_void_pointer p)
+   static pointer allocate(Allocator &a, size_type n, const_void_pointer p)
    {
       const bool value = boost::container::container_detail::
          has_member_function_callable_with_allocate
@@ -312,7 +312,7 @@ struct allocator_traits
    //! <b>Effects</b>: calls <code>a.destroy(p)</code> if that call is well-formed;
    //! otherwise, invokes <code>p->~T()</code>.
    template<class T>
-   BOOST_CONTAINER_FORCEINLINE static void destroy(Allocator &a, T*p) BOOST_NOEXCEPT_OR_NOTHROW
+   static void destroy(Allocator &a, T*p) BOOST_NOEXCEPT_OR_NOTHROW
    {
       typedef T* destroy_pointer;
       const bool value = boost::container::container_detail::
@@ -324,7 +324,7 @@ struct allocator_traits
 
    //! <b>Returns</b>: <code>a.max_size()</code> if that expression is well-formed; otherwise,
    //! <code>numeric_limits<size_type>::max()</code>.
-   BOOST_CONTAINER_FORCEINLINE static size_type max_size(const Allocator &a) BOOST_NOEXCEPT_OR_NOTHROW
+   static size_type max_size(const Allocator &a) BOOST_NOEXCEPT_OR_NOTHROW
    {
       const bool value = allocator_traits_detail::has_max_size<Allocator, size_type (Allocator::*)() const>::value;
       container_detail::bool_<value> flag;
@@ -333,7 +333,7 @@ struct allocator_traits
 
    //! <b>Returns</b>: <code>a.select_on_container_copy_construction()</code> if that expression is well-formed;
    //! otherwise, a.
-   BOOST_CONTAINER_FORCEINLINE static BOOST_CONTAINER_DOC1ST(Allocator,
+   static BOOST_CONTAINER_DOC1ST(Allocator,
       typename container_detail::if_c
          < allocator_traits_detail::has_select_on_container_copy_construction<Allocator BOOST_MOVE_I Allocator (Allocator::*)() const>::value
          BOOST_MOVE_I Allocator BOOST_MOVE_I const Allocator & >::type)
@@ -349,7 +349,7 @@ struct allocator_traits
       //! <b>Effects</b>: calls <code>a.construct(p, std::forward<Args>(args)...)</code> if that call is well-formed;
       //! otherwise, invokes <code>::new (static_cast<void*>(p)) T(std::forward<Args>(args)...)</code>
       template <class T, class ...Args>
-      BOOST_CONTAINER_FORCEINLINE static void construct(Allocator & a, T* p, BOOST_FWD_REF(Args)... args)
+      static void construct(Allocator & a, T* p, BOOST_FWD_REF(Args)... args)
       {
          static const bool value = ::boost::move_detail::and_
             < container_detail::is_not_std_allocator<Allocator>
@@ -363,7 +363,7 @@ struct allocator_traits
 
    //! <b>Returns</b>: <code>a.storage_is_unpropagable(p)</code> if is_partially_propagable::value is true; otherwise,
    //! <code>false</code>.
-   BOOST_CONTAINER_FORCEINLINE static bool storage_is_unpropagable(const Allocator &a, pointer p) BOOST_NOEXCEPT_OR_NOTHROW
+   static bool storage_is_unpropagable(const Allocator &a, pointer p) BOOST_NOEXCEPT_OR_NOTHROW
    {
       container_detail::bool_<is_partially_propagable::value> flag;
       return allocator_traits::priv_storage_is_unpropagable(flag, a, p);
@@ -371,7 +371,7 @@ struct allocator_traits
 
    //! <b>Returns</b>: <code>true</code> if <code>is_always_equal::value == true</code>, otherwise,
    //! <code>a == b</code>.
-   BOOST_CONTAINER_FORCEINLINE static bool equal(const Allocator &a, const Allocator &b) BOOST_NOEXCEPT_OR_NOTHROW
+   static bool equal(const Allocator &a, const Allocator &b) BOOST_NOEXCEPT_OR_NOTHROW
    {
       container_detail::bool_<is_always_equal::value> flag;
       return allocator_traits::priv_equal(flag, a, b);
@@ -379,46 +379,46 @@ struct allocator_traits
 
    #if !defined(BOOST_CONTAINER_DOXYGEN_INVOKED)
    private:
-   BOOST_CONTAINER_FORCEINLINE static pointer priv_allocate(container_detail::true_type, Allocator &a, size_type n, const_void_pointer p)
+   static pointer priv_allocate(container_detail::true_type, Allocator &a, size_type n, const_void_pointer p)
    {  return a.allocate(n, p);  }
 
-   BOOST_CONTAINER_FORCEINLINE static pointer priv_allocate(container_detail::false_type, Allocator &a, size_type n, const_void_pointer)
+   static pointer priv_allocate(container_detail::false_type, Allocator &a, size_type n, const_void_pointer)
    {  return a.allocate(n);  }
 
    template<class T>
-   BOOST_CONTAINER_FORCEINLINE static void priv_destroy(container_detail::true_type, Allocator &a, T* p) BOOST_NOEXCEPT_OR_NOTHROW
+   static void priv_destroy(container_detail::true_type, Allocator &a, T* p) BOOST_NOEXCEPT_OR_NOTHROW
    {  a.destroy(p);  }
 
    template<class T>
-   BOOST_CONTAINER_FORCEINLINE static void priv_destroy(container_detail::false_type, Allocator &, T* p) BOOST_NOEXCEPT_OR_NOTHROW
+   static void priv_destroy(container_detail::false_type, Allocator &, T* p) BOOST_NOEXCEPT_OR_NOTHROW
    {  p->~T(); (void)p;  }
 
-   BOOST_CONTAINER_FORCEINLINE static size_type priv_max_size(container_detail::true_type, const Allocator &a) BOOST_NOEXCEPT_OR_NOTHROW
+   static size_type priv_max_size(container_detail::true_type, const Allocator &a) BOOST_NOEXCEPT_OR_NOTHROW
    {  return a.max_size();  }
 
-   BOOST_CONTAINER_FORCEINLINE static size_type priv_max_size(container_detail::false_type, const Allocator &) BOOST_NOEXCEPT_OR_NOTHROW
+   static size_type priv_max_size(container_detail::false_type, const Allocator &) BOOST_NOEXCEPT_OR_NOTHROW
    {  return size_type(-1)/sizeof(value_type);  }
 
-   BOOST_CONTAINER_FORCEINLINE static Allocator priv_select_on_container_copy_construction(container_detail::true_type, const Allocator &a)
+   static Allocator priv_select_on_container_copy_construction(container_detail::true_type, const Allocator &a)
    {  return a.select_on_container_copy_construction();  }
 
-   BOOST_CONTAINER_FORCEINLINE static const Allocator &priv_select_on_container_copy_construction(container_detail::false_type, const Allocator &a) BOOST_NOEXCEPT_OR_NOTHROW
+   static const Allocator &priv_select_on_container_copy_construction(container_detail::false_type, const Allocator &a) BOOST_NOEXCEPT_OR_NOTHROW
    {  return a;  }
 
    #if !defined(BOOST_NO_CXX11_VARIADIC_TEMPLATES)
       template<class T, class ...Args>
-      BOOST_CONTAINER_FORCEINLINE static void priv_construct(container_detail::true_type, Allocator &a, T *p, BOOST_FWD_REF(Args) ...args)
+      static void priv_construct(container_detail::true_type, Allocator &a, T *p, BOOST_FWD_REF(Args) ...args)
       {  a.construct( p, ::boost::forward<Args>(args)...);  }
 
       template<class T, class ...Args>
-      BOOST_CONTAINER_FORCEINLINE static void priv_construct(container_detail::false_type, Allocator &, T *p, BOOST_FWD_REF(Args) ...args)
+      static void priv_construct(container_detail::false_type, Allocator &, T *p, BOOST_FWD_REF(Args) ...args)
       {  ::new((void*)p, boost_container_new_t()) T(::boost::forward<Args>(args)...); }
    #else // #if !defined(BOOST_NO_CXX11_VARIADIC_TEMPLATES)
       public:
 
       #define BOOST_CONTAINER_ALLOCATOR_TRAITS_CONSTRUCT_IMPL(N) \
       template<class T BOOST_MOVE_I##N BOOST_MOVE_CLASS##N >\
-      BOOST_CONTAINER_FORCEINLINE static void construct(Allocator &a, T *p BOOST_MOVE_I##N BOOST_MOVE_UREF##N)\
+      static void construct(Allocator &a, T *p BOOST_MOVE_I##N BOOST_MOVE_UREF##N)\
       {\
          static const bool value = ::boost::move_detail::and_ \
             < container_detail::is_not_std_allocator<Allocator> \
@@ -438,11 +438,11 @@ struct allocator_traits
       /////////////////////////////////
       #define BOOST_CONTAINER_ALLOCATOR_TRAITS_PRIV_CONSTRUCT_IMPL(N) \
       template<class T BOOST_MOVE_I##N BOOST_MOVE_CLASS##N >\
-      BOOST_CONTAINER_FORCEINLINE static void priv_construct(container_detail::true_type, Allocator &a, T *p BOOST_MOVE_I##N BOOST_MOVE_UREF##N)\
+      static void priv_construct(container_detail::true_type, Allocator &a, T *p BOOST_MOVE_I##N BOOST_MOVE_UREF##N)\
       {  a.construct( p BOOST_MOVE_I##N BOOST_MOVE_FWD##N );  }\
       \
       template<class T BOOST_MOVE_I##N BOOST_MOVE_CLASS##N >\
-      BOOST_CONTAINER_FORCEINLINE static void priv_construct(container_detail::false_type, Allocator &, T *p BOOST_MOVE_I##N BOOST_MOVE_UREF##N)\
+      static void priv_construct(container_detail::false_type, Allocator &, T *p BOOST_MOVE_I##N BOOST_MOVE_UREF##N)\
       {  ::new((void*)p, boost_container_new_t()) T(BOOST_MOVE_FWD##N); }\
       //
       BOOST_MOVE_ITERATE_0TO8(BOOST_CONTAINER_ALLOCATOR_TRAITS_PRIV_CONSTRUCT_IMPL)
@@ -451,19 +451,19 @@ struct allocator_traits
    #endif   // #if !defined(BOOST_NO_CXX11_VARIADIC_TEMPLATES)
 
    template<class T>
-   BOOST_CONTAINER_FORCEINLINE static void priv_construct(container_detail::false_type, Allocator &, T *p, const ::boost::container::default_init_t&)
+   static void priv_construct(container_detail::false_type, Allocator &, T *p, const ::boost::container::default_init_t&)
    {  ::new((void*)p, boost_container_new_t()) T; }
 
-   BOOST_CONTAINER_FORCEINLINE static bool priv_storage_is_unpropagable(container_detail::true_type, const Allocator &a, pointer p)
+   static bool priv_storage_is_unpropagable(container_detail::true_type, const Allocator &a, pointer p)
    {  return a.storage_is_unpropagable(p);  }
 
-   BOOST_CONTAINER_FORCEINLINE static bool priv_storage_is_unpropagable(container_detail::false_type, const Allocator &, pointer)
+   static bool priv_storage_is_unpropagable(container_detail::false_type, const Allocator &, pointer)
    {  return false;  }
 
-   BOOST_CONTAINER_FORCEINLINE static bool priv_equal(container_detail::true_type,  const Allocator &, const Allocator &)
+   static bool priv_equal(container_detail::true_type,  const Allocator &, const Allocator &)
    {  return true;  }
 
-   BOOST_CONTAINER_FORCEINLINE static bool priv_equal(container_detail::false_type, const Allocator &a, const Allocator &b)
+   static bool priv_equal(container_detail::false_type, const Allocator &a, const Allocator &b)
    {  return a == b;  }
 
    #endif   //#if defined(BOOST_CONTAINER_DOXYGEN_INVOKED)

--- a/include/boost/container/container_fwd.hpp
+++ b/include/boost/container/container_fwd.hpp
@@ -115,7 +115,8 @@ template <class T, std::size_t Capacity>
 class static_vector;
 
 template < class T, std::size_t N
-         , class Allocator= new_allocator<T> >
+         , class Allocator= new_allocator<T>
+         , std::size_t alignment= 0 >
 class small_vector;
 
 template <class T

--- a/include/boost/container/small_vector.hpp
+++ b/include/boost/container/small_vector.hpp
@@ -50,7 +50,7 @@ namespace container {
 
 #ifndef BOOST_CONTAINER_DOXYGEN_INVOKED
 
-template <class T, class Allocator = new_allocator<T> >
+template <class T, class Allocator = new_allocator<T>, std::size_t alignment = 0 >
 class small_vector_base;
 
 #endif
@@ -81,7 +81,7 @@ class small_vector_base;
 //! `boost::container::vector< T, small_vector_allocator<Allocator> >`
 //! and internal storage can be obtained downcasting that vector
 //! to `small_vector_base<T>`.
-template<class Allocator>
+template<class Allocator, std::size_t alignment>
 class small_vector_allocator
    : public Allocator
 {
@@ -165,17 +165,17 @@ class small_vector_allocator
 
    //!Constructor from related small_vector_allocator.
    //!Never throws
-   template<class OtherAllocator>
+   template<class OtherAllocator, std::size_t alignment>
    BOOST_CONTAINER_FORCEINLINE small_vector_allocator
-      (const small_vector_allocator<OtherAllocator> &other) BOOST_NOEXCEPT_OR_NOTHROW
+      (const small_vector_allocator<OtherAllocator, alignment> &other) BOOST_NOEXCEPT_OR_NOTHROW
       : Allocator(other.as_base())
    {}
 
    //!Move constructor from related small_vector_allocator.
    //!Never throws
-   template<class OtherAllocator>
+   template<class OtherAllocator, std::size_t alignment>
    BOOST_CONTAINER_FORCEINLINE small_vector_allocator
-      (BOOST_RV_REF(small_vector_allocator<OtherAllocator>) other) BOOST_NOEXCEPT_OR_NOTHROW
+      (BOOST_RV_REF_BEG small_vector_allocator<OtherAllocator, alignment> BOOST_RV_REF_END other) BOOST_NOEXCEPT_OR_NOTHROW
       : Allocator(::boost::move(other.as_base()))
    {}
 
@@ -193,16 +193,16 @@ class small_vector_allocator
 
    //!Assignment from related small_vector_allocator.
    //!Never throws
-   template<class OtherAllocator>
+   template<class OtherAllocator, std::size_t alignment>
    BOOST_CONTAINER_FORCEINLINE small_vector_allocator &
-      operator=(BOOST_COPY_ASSIGN_REF(small_vector_allocator<OtherAllocator>) other) BOOST_NOEXCEPT_OR_NOTHROW
+      operator=(BOOST_COPY_ASSIGN_REF_BEG small_vector_allocator<OtherAllocator, alignment> BOOST_COPY_ASSIGN_REF_END other) BOOST_NOEXCEPT_OR_NOTHROW
    {  return static_cast<small_vector_allocator&>(this->Allocator::operator=(other.as_base()));  }
 
    //!Move assignment from related small_vector_allocator.
    //!Never throws
-   template<class OtherAllocator>
+   template<class OtherAllocator, std::size_t alignment>
    BOOST_CONTAINER_FORCEINLINE small_vector_allocator &
-      operator=(BOOST_RV_REF(small_vector_allocator<OtherAllocator>) other) BOOST_NOEXCEPT_OR_NOTHROW
+      operator=(BOOST_RV_REF_BEG small_vector_allocator<OtherAllocator, alignment> BOOST_RV_REF_END other) BOOST_NOEXCEPT_OR_NOTHROW
    {  return static_cast<small_vector_allocator&>(this->Allocator::operator=(::boost::move(other.as_base())));  }
 
    //!Allocates storage from the standard-conforming allocator
@@ -281,10 +281,10 @@ class small_vector_allocator
 
    pointer internal_storage() const
    {
-      typedef typename Allocator::value_type                                              value_type;
-      typedef container_detail::vector_alloc_holder< small_vector_allocator<Allocator> >  vector_alloc_holder_t;
-      typedef vector<value_type, small_vector_allocator<Allocator> >                      vector_base;
-      typedef small_vector_base<value_type, Allocator>                                    derived_type;
+      typedef typename Allocator::value_type                                                        value_type;
+      typedef container_detail::vector_alloc_holder< small_vector_allocator<Allocator, alignment> > vector_alloc_holder_t;
+      typedef vector<value_type, small_vector_allocator<Allocator, alignment> >                     vector_base;
+      typedef small_vector_base<value_type, Allocator, alignment>                                   derived_type;
       //
       const vector_alloc_holder_t &v_holder = static_cast<const vector_alloc_holder_t &>(*this);
       const vector_base &v_base = reinterpret_cast<const vector_base &>(v_holder);
@@ -319,9 +319,9 @@ class small_vector_allocator
 //!
 //! All `boost::container:vector` member functions are inherited. See `vector` documentation for details.
 //!
-template <class T, class SecondaryAllocator>
+template <class T, class SecondaryAllocator, std::size_t alignment>
 class small_vector_base
-   : public vector<T, small_vector_allocator<SecondaryAllocator> >
+   : public vector<T, small_vector_allocator<SecondaryAllocator, alignment> >
 {
    #ifndef BOOST_CONTAINER_DOXYGEN_INVOKED
    public:
@@ -332,7 +332,7 @@ class small_vector_base
    private: 
    BOOST_COPYABLE_AND_MOVABLE(small_vector_base)
 
-   friend class small_vector_allocator<SecondaryAllocator>;
+   friend class small_vector_allocator<SecondaryAllocator, alignment>;
 
    pointer internal_storage() const BOOST_NOEXCEPT_OR_NOTHROW
    {
@@ -340,14 +340,14 @@ class small_vector_base
          (*const_cast<T*>(static_cast<const T*>(static_cast<const void*>(&m_storage_start))));
    }
 
-   typedef vector<T, small_vector_allocator<SecondaryAllocator> > base_type;
+   typedef vector<T, small_vector_allocator<SecondaryAllocator, alignment> > base_type;
          base_type &as_base()       { return static_cast<base_type&>(*this); }
    const base_type &as_base() const { return static_cast<const base_type&>(*this); }
 
    public:
    typedef typename container_detail::aligned_storage
-      <sizeof(T), container_detail::alignment_of<T>::value>::type storage_type;
-   typedef small_vector_allocator<SecondaryAllocator>             allocator_type;
+      <sizeof(T), (alignment > 0) ? alignment : container_detail::alignment_of<T>::value>::type storage_type;
+   typedef small_vector_allocator<SecondaryAllocator, alignment>             allocator_type;
 
    protected:
    typedef typename base_type::initial_capacity_t initial_capacity_t;
@@ -414,12 +414,12 @@ struct small_vector_storage_calculator_helper<Needed, Hdr, SSize, true>
    static const std::size_t value = 0u;
 };
 
-template<class Storage, class Allocator, class T, std::size_t N>
+template<class Storage, class Allocator, class T, std::size_t N, std::size_t alignment>
 struct small_vector_storage_calculator
 {
-   typedef small_vector_base<T, Allocator> svh_type;
-   typedef vector<T, small_vector_allocator<Allocator> > svhb_type;
-   static const std::size_t s_align = container_detail::alignment_of<Storage>::value;
+   typedef small_vector_base<T, Allocator, alignment> svh_type;
+   typedef vector<T, small_vector_allocator<Allocator, alignment> > svhb_type;
+   static const std::size_t s_align = alignment > 0 ? alignment : container_detail::alignment_of<Storage>::value;
    static const std::size_t s_size = sizeof(Storage);
    static const std::size_t svh_sizeof = sizeof(svh_type);
    static const std::size_t svhb_sizeof = sizeof(svhb_type);
@@ -445,13 +445,13 @@ template<class Storage>
 struct small_vector_storage<Storage, 0>
 {};
 
-template<class Allocator, std::size_t N>
+template<class Allocator, std::size_t N, std::size_t alignment>
 struct small_vector_storage_definer
 {
-   typedef typename Allocator::value_type                                  value_type;
-   typedef typename small_vector_base<value_type, Allocator>::storage_type storage_type;
+   typedef typename Allocator::value_type                                               value_type;
+   typedef typename small_vector_base<value_type, Allocator, alignment>::storage_type   storage_type;
    static const std::size_t needed_extra_storages =
-      small_vector_storage_calculator<storage_type, Allocator, value_type, N>::needed_extra_storages;
+      small_vector_storage_calculator<storage_type, Allocator, value_type, N, alignment>::needed_extra_storages;
    typedef small_vector_storage<storage_type, needed_extra_storages> type;
 };
 
@@ -469,15 +469,16 @@ struct small_vector_storage_definer
 //! \tparam T The type of object that is stored in the small_vector
 //! \tparam N The number of preallocated elements stored inside small_vector. It shall be less than Allocator::max_size();
 //! \tparam Allocator The allocator used for memory management when the number of elements exceeds N.
-template <class T, std::size_t N, class Allocator BOOST_CONTAINER_DOCONLY(= new_allocator<T>) >
-class small_vector : public small_vector_base<T, Allocator>
+//! \tparam alignment Alignment of the prealocated storage. alignment == 0 uses default alignment.
+template <class T, std::size_t N, class Allocator BOOST_CONTAINER_DOCONLY(= new_allocator<T>), std::size_t alignment BOOST_CONTAINER_DOCONLY(= 0)>
+class small_vector : public small_vector_base<T, Allocator, alignment>
    #ifndef BOOST_CONTAINER_DOXYGEN_INVOKED
-   , private small_vector_storage_definer<Allocator, N>::type
+   , private small_vector_storage_definer<Allocator, N, alignment>::type
    #endif
 {
    #ifndef BOOST_CONTAINER_DOXYGEN_INVOKED
-   typedef small_vector_base<T, Allocator> base_type;
-   typedef typename small_vector_storage_definer<Allocator, N>::type remaining_storage_holder;
+   typedef small_vector_base<T, Allocator, alignment> base_type;
+   typedef typename small_vector_storage_definer<Allocator, N, alignment>::type remaining_storage_holder;
 
    BOOST_COPYABLE_AND_MOVABLE(small_vector)
 
@@ -485,8 +486,8 @@ class small_vector : public small_vector_base<T, Allocator>
    typedef allocator_traits<typename base_type::allocator_type> allocator_traits_type;
 
    public:
-   typedef small_vector_storage_calculator< typename small_vector_base<T, Allocator>
-      ::storage_type, Allocator, T, N> storage_test;
+   typedef small_vector_storage_calculator< typename small_vector_base<T, Allocator, alignment>
+      ::storage_type, Allocator, T, N, alignment> storage_test;
 
    static const std::size_t needed_extra_storages =  storage_test::needed_extra_storages;
    static const std::size_t needed_bytes =  storage_test::needed_bytes;


### PR DESCRIPTION
Hi,
in order to be able to use small_vectors for SSE aligned doubles, I've
added an alignment specification for small_vector which ensures alignment
of the internal-storage. 
The default value of 0 for the new template parameter ensures the original alignment-calculation.

Tobias