### PR TITLE
Fixed bug Trac #13038

### DIFF
--- a/build/Jamfile.v2
+++ b/build/Jamfile.v2
@@ -4,6 +4,8 @@
 # Boost Software License, Version 1.0. (See accompanying file
 # LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+import sequence ;
+
 project boost/container
     : source-location ../src
     : usage-requirements  # pass these requirement to dependents (i.e. users)
@@ -12,7 +14,7 @@ project boost/container
     ;
 
 lib boost_container
-   : alloc_lib.c [ glob *.cpp ]
+   : alloc_lib.c [ sequence.insertion-sort [ glob *.cpp ] ]
    : <link>shared:<define>BOOST_CONTAINER_DYN_LINK=1
      <link>static:<define>BOOST_CONTAINER_STATIC_LINK=1
    ;


### PR DESCRIPTION
Have constant link order
to make builds reproducible.
See https://reproducible-builds.org/ for why this is good.

Without this patch g++ would order functions in libboost_container.so.1.64.0
depending on random order of files in the build system's filesystem.