### PR TITLE
Fix integer rollover that triggers clang ubsan when U is unsigned

### DIFF
--- a/include/boost/container/detail/copy_move_algo.hpp
+++ b/include/boost/container/detail/copy_move_algo.hpp
@@ -963,7 +963,8 @@ template
 inline typename container_detail::disable_if_trivially_destructible<I, void>::type
    destroy_alloc_n(Allocator &a, I f, U n)
 {
-   while(n--){
+   while(n){
+      --n;
       allocator_traits<Allocator>::destroy(a, boost::movelib::iterator_to_raw_pointer(f));
       ++f;
    }


### PR DESCRIPTION
If U is unsigned in destroy_alloc_n, n-- can lead to unsigned integer rollover when n is 0.
This behavior, while trivial and defined, is sufficient to trigger clang's ubsan detector and create excess noise.

> /mnt/fscratch0/pub/dependencies/boost/boost/container/detail/copy_move_algo.hpp:966:11: runtime error: unsigned integer overflow: 0 - 1 cannot be represented in type 'unsigned long'