### PR TITLE
Remove boost_timer from test/Jamfile.v2

### DIFF
--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -27,7 +27,7 @@ rule test_all
 
    for local fileb in [ glob *.cpp ]
    {
-      all_rules += [ run $(fileb)  /boost/container//boost_container /boost/timer//boost_timer
+      all_rules += [ run $(fileb)  /boost/container//boost_container # /boost/timer//boost_timer
       :  # additional args
       :  # test-files
       :  # requirements


### PR DESCRIPTION
`depinst.py` finds no references to Boost.Timer and doesn't install it, so I'm creating this PR to take it out and see if testing will succeed on Travis.