### PR TITLE
Fix splice for slist

### DIFF
--- a/include/boost/container/slist.hpp
+++ b/include/boost/container/slist.hpp
@@ -1471,7 +1471,7 @@ class slist
    //! <b>Note</b>: Iterators of values obtained from list x now point to elements of this
    //!   list. Iterators of this list and all the references are not invalidated.
    void splice(const_iterator p, slist& x, const_iterator i) BOOST_NOEXCEPT_OR_NOTHROW
-   {  this->splice_after(this->previous(p), x, this->previous(i));  }
+   {  this->splice_after(this->previous(p), x, x.previous(i));  }
 
    //! <b>Requires</b>: p must point to an element contained
    //!   by this list. i must point to an element contained in list x.
@@ -1505,7 +1505,7 @@ class slist
    //! <b>Note</b>: Iterators of values obtained from list x now point to elements of this
    //!   list. Iterators of this list and all the references are not invalidated.
    void splice(const_iterator p, slist& x, const_iterator first, const_iterator last) BOOST_NOEXCEPT_OR_NOTHROW
-   {  this->splice_after(this->previous(p), x, this->previous(first), this->previous(last));  }
+   {  this->splice_after(this->previous(p), x, x.previous(first), x.previous(last));  }
 
    //! <b>Requires</b>: p must point to an element contained
    //!   by this list. first and last must point to elements contained in list x.

--- a/test/global_resource_test.cpp
+++ b/test/global_resource_test.cpp
@@ -27,25 +27,17 @@ std::size_t allocation_count = 0;
 #pragma warning (disable : 4290)
 #endif
 
-#if defined(BOOST_GCC) && (BOOST_GCC >= 40700) && (__cplusplus >= 201103L)
-#define BOOST_CONTAINER_NEW_EXCEPTION_SPECIFIER
-#define BOOST_CONTAINER_DELETE_EXCEPTION_SPECIFIER noexcept
-#else
-#define BOOST_CONTAINER_NEW_EXCEPTION_SPECIFIER    throw(std::bad_alloc)
-#define BOOST_CONTAINER_DELETE_EXCEPTION_SPECIFIER throw()
-#endif
-
 #if defined(BOOST_GCC) && (BOOST_GCC >= 50000)
 #pragma GCC diagnostic ignored "-Wsized-deallocation"
 #endif
 
-void* operator new[](std::size_t count) BOOST_CONTAINER_NEW_EXCEPTION_SPECIFIER
+void* operator new[](std::size_t count) BOOST_NOEXCEPT_IF(false)
 {
    ++allocation_count;
    return std::malloc(count);
 }
 
-void operator delete[](void *p) BOOST_CONTAINER_DELETE_EXCEPTION_SPECIFIER
+void operator delete[](void *p) BOOST_NOEXCEPT
 {
    --allocation_count;
    return std::free(p);

--- a/test/slist_test.cpp
+++ b/test/slist_test.cpp
@@ -135,6 +135,33 @@ bool test_support_for_initializer_list()
    return true;
 }
 
+bool test_for_splice()
+{
+   {
+      slist<int> list1; list1.push_front(3); list1.push_front(2); list1.push_front(1); list1.push_front(0);
+      slist<int> list2;
+      slist<int> expected1; expected1.push_front(3); expected1.push_front(2);  expected1.push_front(0);
+      slist<int> expected2; expected2.push_front(1);
+
+      list2.splice(list2.begin(), list1, ++list1.begin());
+
+      if (!(expected1 == list1 && expected2 == list2))
+         return false;
+   }
+   {
+      slist<int> list1; list1.push_front(3); list1.push_front(2); list1.push_front(1); list1.push_front(0);
+      slist<int> list2;
+      slist<int> expected1;
+      slist<int> expected2; expected2.push_front(3); expected2.push_front(2); expected2.push_front(1); expected2.push_front(0);
+
+      list2.splice(list2.begin(), list1, list1.begin(), list1.end());
+
+      if (!(expected1 == list1 && expected2 == list2))
+         return false;
+   }
+   return true;
+}
+
 struct boost_container_slist;
 
 namespace boost {
@@ -205,6 +232,12 @@ int main ()
    //    Initializer lists
    ////////////////////////////////////
    if(!test_support_for_initializer_list())
+      return 1;
+
+   ////////////////////////////////////
+   //    Splice testing
+   ////////////////////////////////////
+   if(!test_for_splice())
       return 1;
 
    ////////////////////////////////////


### PR DESCRIPTION
The call of the splice method with iterators leads to an infinite loop inside common_slist_algorithms::get_previous_node

slist<int> lst1 = { 0, 1, 2, 3 };
slist<int> lst2;
lst2.splice(lst2.begin(), lst1, lst1.begin());

expected:
lst1 == { 1, 2, 3 }
lst2 == { 0 }