### PR TITLE
Allow vector to be assigned to itself

### DIFF
--- a/include/boost/container/vector.hpp
+++ b/include/boost/container/vector.hpp
@@ -1131,7 +1131,8 @@ class vector
       BOOST_NOEXCEPT_IF(allocator_traits_type::propagate_on_container_move_assignment::value
                         || allocator_traits_type::is_always_equal::value)
    {
-      BOOST_ASSERT(&x != this);
+      if (&x == this)
+         return *this;
       this->priv_move_assign(boost::move(x));
       return *this;
    }


### PR DESCRIPTION
This sounds like an odd thing to do but some implementations of `std::random_shuffle()` do this because they call `std::swap(x, x)` (and cppreference implies that they are allowed to). Old versions of libstdc++ used to do this but now they don't. The current as-of-now version of libc++ does it for one variant of `std::random_shuffle()` but not others. I have opened [a bug](https://bugs.llvm.org/show_bug.cgi?id=38900) for them to fix that, but `swap(a, a)` should still be allowed anyway.

Quoting [cppreference](https://en.cppreference.com/w/cpp/named_req/Swappable):

> C++ named requirements: Swappable
> Any lvalue or rvalue of this type can be swapped with any lvalue or rvalue of some other type

Also [relevant SO question](https://stackoverflow.com/questions/24444630/is-stdswapx-x-guaranteed-to-leave-x-unchanged)