### PR TITLE
add missing warning re-enabling include

### DIFF
--- a/include/boost/container/detail/thread_mutex.hpp
+++ b/include/boost/container/detail/thread_mutex.hpp
@@ -176,4 +176,6 @@ class thread_mutex
 
 #endif   //BOOST_HAS_PTHREADS
 
+#include <boost/container/detail/config_end.hpp>
+
 #endif // #ifndef BOOST_CONTAINER_DETAIL_THREAD_MUTEX_HPP


### PR DESCRIPTION
fixes msvc warning C5032: "detected #pragma warning(push) with no corresponding #pragma warning(pop)"