### PR TITLE
 merge CTADs with equivalent parameter-declaration-clauses

### DIFF
--- a/include/boost/container/flat_map.hpp
+++ b/include/boost/container/flat_map.hpp
@@ -49,6 +49,10 @@
 #include <initializer_list>
 #endif
 
+#ifndef BOOST_CONTAINER_NO_CXX17_CTAD
+#include <type_traits>
+#endif
+
 namespace boost {
 namespace container {
 
@@ -1585,20 +1589,21 @@ flat_map(InputIterator, InputIterator) ->
    flat_map< it_based_non_const_first_type_t<InputIterator>
            , it_based_second_type_t<InputIterator>>;
 
-template < typename InputIterator, typename Allocator
-         , typename = dtl::require_allocator_t<Allocator>>
-flat_map(InputIterator, InputIterator, Allocator const&) ->
-   flat_map< it_based_non_const_first_type_t<InputIterator>
-           , it_based_second_type_t<InputIterator>
-           , std::less<it_based_non_const_first_type_t<InputIterator>>
-           , Allocator>;
-
-template < typename InputIterator, typename Compare
-         , typename = dtl::require_nonallocator_t<Compare>>
-flat_map(InputIterator, InputIterator, Compare const&) ->
-   flat_map< it_based_non_const_first_type_t<InputIterator>
-           , it_based_second_type_t<InputIterator>
-           , Compare>;
+template < typename InputIterator, typename AllocatorOrCompare>
+    flat_map(InputIterator, InputIterator, AllocatorOrCompare const&) ->
+    flat_map< it_based_non_const_first_type_t<InputIterator>
+            , it_based_second_type_t<InputIterator>
+            , std::conditional_t<                                                                                               // Compare
+                dtl::is_allocator<AllocatorOrCompare>::value
+                , std::less<it_based_non_const_first_type_t<InputIterator>>
+                , AllocatorOrCompare
+                >
+            , std::conditional_t<                                                                                               // Allocator
+                dtl::is_allocator<AllocatorOrCompare>::value
+                , AllocatorOrCompare
+                , new_allocator<std::pair<it_based_non_const_first_type_t<InputIterator>, it_based_second_type_t<InputIterator>>>
+                >
+            >;
 
 template < typename InputIterator, typename Compare, typename Allocator
          , typename = dtl::require_nonallocator_t<Compare>
@@ -1614,20 +1619,21 @@ flat_map(ordered_unique_range_t, InputIterator, InputIterator) ->
    flat_map< it_based_non_const_first_type_t<InputIterator>
            , it_based_second_type_t<InputIterator>>;
 
-template < typename InputIterator, typename Allocator
-         , typename = dtl::require_allocator_t<Allocator>>
-flat_map(ordered_unique_range_t, InputIterator, InputIterator, Allocator const&) ->
+template < typename InputIterator, typename AllocatorOrCompare>
+flat_map(ordered_unique_range_t, InputIterator, InputIterator, AllocatorOrCompare const&) ->
    flat_map< it_based_non_const_first_type_t<InputIterator>
            , it_based_second_type_t<InputIterator>
-           , std::less<it_based_non_const_first_type_t<InputIterator>>
-           , Allocator>;
-
-template < typename InputIterator, typename Compare
-         , typename = dtl::require_nonallocator_t<Compare>>
-flat_map(ordered_unique_range_t, InputIterator, InputIterator, Compare const&) ->
-   flat_map< it_based_non_const_first_type_t<InputIterator>
-           , it_based_second_type_t<InputIterator>
-           , Compare>;
+           , std::conditional_t<                                                                                               // Compare
+               dtl::is_allocator<AllocatorOrCompare>::value
+               , std::less<it_based_non_const_first_type_t<InputIterator>>
+               , AllocatorOrCompare
+               >
+           , std::conditional_t<                                                                                               // Allocator
+               dtl::is_allocator<AllocatorOrCompare>::value
+               , AllocatorOrCompare
+               , new_allocator<std::pair<it_based_non_const_first_type_t<InputIterator>, it_based_second_type_t<InputIterator>>>
+               >
+           >;
 
 template < typename InputIterator, typename Compare, typename Allocator
          , typename = dtl::require_nonallocator_t<Compare>
@@ -2891,20 +2897,21 @@ flat_multimap(InputIterator, InputIterator) ->
    flat_multimap< it_based_non_const_first_type_t<InputIterator>
                 , it_based_second_type_t<InputIterator>>;
 
-template < typename InputIterator, typename Allocator
-         , typename = dtl::require_allocator_t<Allocator>>
-flat_multimap(InputIterator, InputIterator, Allocator const&) ->
+template < typename InputIterator, typename AllocatorOrCompare>
+flat_multimap(InputIterator, InputIterator, AllocatorOrCompare const&) ->
    flat_multimap< it_based_non_const_first_type_t<InputIterator>
                 , it_based_second_type_t<InputIterator>
-                , std::less<it_based_non_const_first_type_t<InputIterator>>
-                , Allocator>;
-
-template < typename InputIterator, typename Compare
-         , typename = dtl::require_nonallocator_t<Compare>>
-flat_multimap(InputIterator, InputIterator, Compare const&) ->
-   flat_multimap< it_based_non_const_first_type_t<InputIterator>
-                , it_based_second_type_t<InputIterator>
-                , Compare>;
+                , std::conditional_t<                                                                                               // Compare
+                    dtl::is_allocator<AllocatorOrCompare>::value
+                    , std::less<it_based_non_const_first_type_t<InputIterator>>
+                    , AllocatorOrCompare
+                    >
+                , std::conditional_t<                                                                                               // Allocator
+                    dtl::is_allocator<AllocatorOrCompare>::value
+                    , AllocatorOrCompare
+                    , new_allocator<std::pair<it_based_non_const_first_type_t<InputIterator>, it_based_second_type_t<InputIterator>>>
+                    >
+                >;
 
 template < typename InputIterator, typename Compare, typename Allocator
          , typename = dtl::require_nonallocator_t<Compare>
@@ -2920,20 +2927,21 @@ flat_multimap(ordered_range_t, InputIterator, InputIterator) ->
    flat_multimap< it_based_non_const_first_type_t<InputIterator>
                 , it_based_second_type_t<InputIterator>>;
 
-template < typename InputIterator, typename Allocator
-         , typename = dtl::require_allocator_t<Allocator>>
-flat_multimap(ordered_range_t, InputIterator, InputIterator, Allocator const&) ->
+template < typename InputIterator, typename AllocatorOrCompare>
+flat_multimap(ordered_range_t, InputIterator, InputIterator, AllocatorOrCompare const&) ->
    flat_multimap< it_based_non_const_first_type_t<InputIterator>
                 , it_based_second_type_t<InputIterator>
-                , std::less<it_based_non_const_first_type_t<InputIterator>>
-                , Allocator>;
-
-template < typename InputIterator, typename Compare
-         , typename = dtl::require_nonallocator_t<Compare>>
-flat_multimap(ordered_range_t, InputIterator, InputIterator, Compare const&) ->
-   flat_multimap< it_based_non_const_first_type_t<InputIterator>
-                , it_based_second_type_t<InputIterator>
-                , Compare>;
+                , std::conditional_t<                                                                                               // Compare
+                    dtl::is_allocator<AllocatorOrCompare>::value
+                    , std::less<it_based_non_const_first_type_t<InputIterator>>
+                    , AllocatorOrCompare
+                    >
+                , std::conditional_t<                                                                                               // Allocator
+                    dtl::is_allocator<AllocatorOrCompare>::value
+                    , AllocatorOrCompare
+                    , new_allocator<std::pair<it_based_non_const_first_type_t<InputIterator>, it_based_second_type_t<InputIterator>>>
+                    >
+                >;
 
 template < typename InputIterator, typename Compare, typename Allocator
          , typename = dtl::require_nonallocator_t<Compare>


### PR DESCRIPTION
This PR fixes compilation errors with VS 2017 (/std:c++latest /permissive-).
VS 2017 seems to have a very strict interpretation of  [temp.deduct.guide] (3):

> ... Two deduction guide declarations in the same translation unit for the same class template shall
not have equivalent parameter-declaration-clauses.

Both gcc and clang seem to ignore [temp.deduct.guide] (3), or only considering it for viable CTAD candidates.

NB: There seems to be no explicit explanation, when two parameter-declaration-clauses are equivalent, especially if templates are involved.
 
