### PR TITLE
Workaround: Intel compilers do not offer CTAD yet.

### DIFF
--- a/include/boost/container/detail/workaround.hpp
+++ b/include/boost/container/detail/workaround.hpp
@@ -121,9 +121,13 @@
 
 
 #if (__cplusplus >= 201703L)
-//CTAD supported
+   //CTAD supported
+   #ifdef __INTEL_COMPILER
+      //Intel compilers do not offer this feature yet
+      #define BOOST_CONTAINER_NO_CXX17_CTAD
+   #endif
 #else
-#define BOOST_CONTAINER_NO_CXX17_CTAD
+   #define BOOST_CONTAINER_NO_CXX17_CTAD
 #endif
 
 #endif   //#ifndef BOOST_CONTAINER_DETAIL_WORKAROUND_HPP


### PR DESCRIPTION
Closes #95. See issue for further information.