### PR TITLE
Fix deallocating never-allocated storage in vector.merge()

### DIFF
--- a/include/boost/container/vector.hpp
+++ b/include/boost/container/vector.hpp
@@ -2373,7 +2373,9 @@ private:
       pointer const old_p     = this->m_holder.start();
       size_type const old_cap = this->m_holder.capacity();
       boost::container::destroy_alloc_n(a, boost::movelib::to_raw_pointer(old_p), old_size);
-      this->m_holder.deallocate(old_p, old_cap);
+      if (old_cap > 0) {
+         this->m_holder.deallocate(old_p, old_cap);
+      }
       this->m_holder.m_size = old_size + added;
       this->m_holder.start(new_storage);
       this->m_holder.capacity(new_cap);


### PR DESCRIPTION
If merge() is called on an empty vector, then priv_merge_in_new_buffer() will
call deallocate() with size 0 on the old (not-yet-allocated) vector storage.
This violates the Allocator requirement that the pointer passed to deallocate()
must have come from a call to allocate() with the same size.

Fix this by checking old_cap against 0, and also add a unit test for this bug.