### PR TITLE
Fix -Wmissing-noreturn clang warnings

### DIFF
--- a/include/boost/container/throw_exception.hpp
+++ b/include/boost/container/throw_exception.hpp
@@ -49,7 +49,7 @@ namespace container {
 
 #elif defined(BOOST_NO_EXCEPTIONS)
 
-   inline void throw_bad_alloc()
+   BOOST_NORETURN inline void throw_bad_alloc()
    {
       const char msg[] = "boost::container bad_alloc thrown";
       (void)msg;
@@ -57,7 +57,7 @@ namespace container {
       std::abort();
    }
 
-   inline void throw_out_of_range(const char* str)
+   BOOST_NORETURN inline void throw_out_of_range(const char* str)
    {
       const char msg[] = "boost::container out_of_range thrown";
       (void)msg; (void)str;
@@ -65,7 +65,7 @@ namespace container {
       std::abort();
    }
 
-   inline void throw_length_error(const char* str)
+   BOOST_NORETURN inline void throw_length_error(const char* str)
    {
       const char msg[] = "boost::container length_error thrown";
       (void)msg; (void)str;
@@ -73,7 +73,7 @@ namespace container {
       std::abort();
    }
 
-   inline void throw_logic_error(const char* str)
+   BOOST_NORETURN inline void throw_logic_error(const char* str)
    {
       const char msg[] = "boost::container logic_error thrown";
       (void)msg; (void)str;
@@ -81,7 +81,7 @@ namespace container {
       std::abort();
    }
 
-   inline void throw_runtime_error(const char* str)
+   BOOST_NORETURN inline void throw_runtime_error(const char* str)
    {
       const char msg[] = "boost::container runtime_error thrown";
       (void)msg; (void)str;
@@ -102,7 +102,7 @@ namespace container {
    //! <li>If BOOST_NO_EXCEPTIONS and BOOST_CONTAINER_USER_DEFINED_THROW_CALLBACKS are defined
    //!   the user must provide an implementation and the function should not return.</li>
    //! </ul>
-   inline void throw_bad_alloc()
+   BOOST_NORETURN inline void throw_bad_alloc()
    {
       throw std::bad_alloc();
    }
@@ -118,7 +118,7 @@ namespace container {
    //! <li>If BOOST_NO_EXCEPTIONS and BOOST_CONTAINER_USER_DEFINED_THROW_CALLBACKS are defined
    //!   the user must provide an implementation and the function should not return.</li>
    //! </ul>
-   inline void throw_out_of_range(const char* str)
+   BOOST_NORETURN inline void throw_out_of_range(const char* str)
    {
       throw std::out_of_range(str);
    }
@@ -134,7 +134,7 @@ namespace container {
    //! <li>If BOOST_NO_EXCEPTIONS and BOOST_CONTAINER_USER_DEFINED_THROW_CALLBACKS are defined
    //!   the user must provide an implementation and the function should not return.</li>
    //! </ul>
-   inline void throw_length_error(const char* str)
+   BOOST_NORETURN inline void throw_length_error(const char* str)
    {
       throw std::length_error(str);
    }
@@ -151,7 +151,7 @@ namespace container {
    //! <li>If BOOST_NO_EXCEPTIONS and BOOST_CONTAINER_USER_DEFINED_THROW_CALLBACKS are defined
    //!   the user must provide an implementation and the function should not return.</li>
    //! </ul>
-   inline void throw_logic_error(const char* str)
+   BOOST_NORETURN inline void throw_logic_error(const char* str)
    {
       throw std::logic_error(str);
    }
@@ -167,7 +167,7 @@ namespace container {
    //! <li>If BOOST_NO_EXCEPTIONS and BOOST_CONTAINER_USER_DEFINED_THROW_CALLBACKS are defined
    //!   the user must provide an implementation and the function should not return.</li>
    //! </ul>
-   inline void throw_runtime_error(const char* str)
+   BOOST_NORETURN inline void throw_runtime_error(const char* str)
    {
       throw std::runtime_error(str);
    }


### PR DESCRIPTION
Mark functions only throwing exceptions or calling `std::abort` with
`BOOST_NORETURN`.