### PR TITLE
Fix gcc -Wdeprecated-copy

### DIFF
--- a/include/boost/container/vector.hpp
+++ b/include/boost/container/vector.hpp
@@ -120,6 +120,15 @@ class vec_iterator
       :  m_ptr(other.get_ptr())
    {}
 
+   BOOST_CONTAINER_FORCEINLINE vec_iterator& operator=(vec_iterator<Pointer, false> const& other) BOOST_NOEXCEPT_OR_NOTHROW
+   {
+       if (&other != this){
+           this->m_ptr = other.get_ptr();
+       }
+       return *this;
+   }
+
+
    //Pointer like operators
    BOOST_CONTAINER_FORCEINLINE reference operator*()   const BOOST_NOEXCEPT_OR_NOTHROW
    {  BOOST_ASSERT(!!m_ptr);  return *m_ptr;  }


### PR DESCRIPTION
Hello,

I spotted this while compiling FB Folly

```
/path/include/boost/container/flat_map.hpp:1530:12: error: implicitly-declared 'constexpr boost::container::vec_iterator<std::pair<int, int>*, false>& boost::container:
:vec_iterator<std::pair<int, int>*, false>::operator=(const boost::container::vec_iterator<std::pair<int, int>*, false>&)' is deprecated [-Werror=deprecated-copy]
 1530 |          i = insert(i, impl_value_type(k, ::boost::move(m.m_t)));
In file included from /path/include/boost/container/detail/flat_tree.hpp:30,
                 from /path/include/boost/container/flat_map.hpp:29,
                 from ...
/path/include/boost/container/vector.hpp:119:32: note: because 'boost::container::vec_iterator<std::pair<int, int>*, false>' has user-provided 'boost::container::vec_it
erator<Pointer, IsConst>::vec_iterator(const boost::container::vec_iterator<Pointer, false>&) [with Pointer = std::pair<int, int>*; bool IsConst = false]'
  119 |    BOOST_CONTAINER_FORCEINLINE vec_iterator(vec_iterator<Pointer, false> const& other) BOOST_NOEXCEPT_OR_NOTHROW
      |                                ^~~~~~~~~~~~
```

As you don't use defaulted syntax ( = default) nor import <algorithm>, I did not dare using defaulted assignment operator syntax nor std::swap.

Stac