### PR TITLE
[CMake] Add minimal cmake support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,39 @@
+# Copyright 2019 Mike Dev
+# Distributed under the Boost Software License, Version 1.0.
+# See accompanying file LICENSE_1_0.txt or copy at https://www.boost.org/LICENSE_1_0.txt
+#
+# NOTE: CMake support for Boost.Container is currently experimental at best
+#       and the interface is likely to change in the future
+
+cmake_minimum_required( VERSION 3.5 )
+project( BoostContainer LANGUAGES C CXX )
+
+file( GLOB boost_container_cpp_files src/*.cpp )
+
+add_library(boost_container
+    ${boost_container_cpp_files}
+    src/alloc_lib.c
+)
+
+# This is the public target name, other libraries should link to
+add_library( Boost::container ALIAS boost_container )
+
+target_include_directories( boost_container PUBLIC include )
+
+# NOTE:
+# We deactivate autolinking, because cmake based builds don't need it and
+# we don't implement name mangling for the library file anyway.
+# Ususally the parent CMakeLists.txt file should already have globally defined BOOST_ALL_NO_LIB
+target_compile_definitions( boost_container PUBLIC BOOST_CONTAINER_NO_LIB )
+
+target_link_libraries( boost_container
+    PUBLIC
+        Boost::assert
+        Boost::config
+        Boost::container_hash
+        Boost::core
+        Boost::intrusive
+        Boost::move
+        Boost::static_assert
+        Boost::type_traits
+)


### PR DESCRIPTION
This cmake file just provides the minimal infrastructure necessary, such that other libraries can get a sensible result from calling


    add_subdirectory( <path-to-boost_container> )
    target_link_libraries( <my_target> PUBLIC Boost::container )


provided that all direct and indirect dependencies are also being added via `add_subdirectory` (which can e.g happen via globbing expression).

More information:

    * https://groups.google.com/forum/#!topic/boost-developers-archive/9ZdrVbAn1aU


Of course the file can be extended to e.g. build and run tests and support installation, but that is out of scope for this particular PR.

Please note that this is largely orthogonal to the recent addition to b2/boost by peter dimov, which is concerned with providing cmake config files for "classic" boost installations via b2.
