### PR TITLE
Get rid of integer overflow in copy_move_algo.hpp (-fsanitize=integer).

### DIFF
--- a/include/boost/container/detail/copy_move_algo.hpp
+++ b/include/boost/container/detail/copy_move_algo.hpp
@@ -522,9 +522,9 @@ inline typename dtl::disable_if_memtransfer_copy_constructible<I, F, I>::type
 {
    F back = r;
    BOOST_TRY{
-      while (n--) {
+      while (n) {
          boost::container::construct_in_place(a, boost::movelib::iterator_to_raw_pointer(r), f);
-         ++f; ++r;
+         ++f; ++r; --n;
       }
    }
    BOOST_CATCH(...){


### PR DESCRIPTION
When running a program with -fsanitize=integer, I get runtime errors on line 514 of copy_move_algo.hpp due to the way the while loop is written:

[...] boost/container/detail/copy_move_algo.hpp:514:15: runtime error: unsigned integer overflow: 0 - 1 cannot be represented in type 'typename boost::container::allocator_traits<new_allocator<pair<unsigned int, __normal_iterator<const unsigned int *, vector<unsigned int, allocator<unsigned int> > > > > >::size_type' (aka 'unsigned long')

When the loop terminates, n-- will cause unsigned integer overflow in n.  Although the value of n is discarded otherwise, this behavior is likely unwanted and unintentional, thus I'm submitting this PR.