### PR TITLE
Avoid gcc 9 deprecated copy warnings in new_allocator.hpp.

### DIFF
--- a/include/boost/container/new_allocator.hpp
+++ b/include/boost/container/new_allocator.hpp
@@ -72,6 +72,13 @@ class new_allocator<void>
    new_allocator(const new_allocator &) BOOST_NOEXCEPT_OR_NOTHROW
    {}
 
+   //!Copy assignment operator from other new_allocator.
+   //!Never throws
+   new_allocator& operator=(const new_allocator &) BOOST_NOEXCEPT_OR_NOTHROW
+   {
+       return *this;
+   }
+
    //!Constructor from related new_allocator.
    //!Never throws
    template<class T2>
@@ -129,6 +136,13 @@ class new_allocator
    //!Never throws
    new_allocator(const new_allocator &) BOOST_NOEXCEPT_OR_NOTHROW
    {}
+
+   //!Copy assignment operator from other new_allocator.
+   //!Never throws
+   new_allocator& operator=(const new_allocator &) BOOST_NOEXCEPT_OR_NOTHROW
+   {
+       return *this;
+   }
 
    //!Constructor from related new_allocator.
    //!Never throws


### PR DESCRIPTION
Hi,

You recently merged similar pull requests for similar issues: deprecated copy warnings in gcc 9.

Cheers,
Romain