### PR TITLE
Prefix aligned_storage with dtl:: (workaround for msvc 10, 11, 12).

### DIFF
--- a/include/boost/container/detail/advanced_insert_int.hpp
+++ b/include/boost/container/detail/advanced_insert_int.hpp
@@ -128,7 +128,7 @@ struct insert_value_initialized_n_proxy
    void copy_n_and_update(Allocator &a, Iterator p, size_type n) const
    {
       for (; 0 < n; --n, ++p){
-         typename aligned_storage<sizeof(value_type), alignment_of<value_type>::value>::type v;
+         typename dtl::aligned_storage<sizeof(value_type), dtl::alignment_of<value_type>::value>::type v;
          value_type *vp = reinterpret_cast<value_type *>(v.data);
          alloc_traits::construct(a, vp);
          value_destructor<Allocator> on_exit(a, *vp); (void)on_exit;
@@ -151,7 +151,7 @@ struct insert_default_initialized_n_proxy
    {
       if(!is_pod<value_type>::value){
          for (; 0 < n; --n, ++p){
-            typename aligned_storage<sizeof(value_type), alignment_of<value_type>::value>::type v;
+            typename dtl::aligned_storage<sizeof(value_type), dtl::alignment_of<value_type>::value>::type v;
             value_type *vp = reinterpret_cast<value_type *>(v.data);
             alloc_traits::construct(a, vp, default_init);
             value_destructor<Allocator> on_exit(a, *vp); (void)on_exit;
@@ -288,7 +288,7 @@ struct insert_emplace_proxy
    void priv_copy_some_and_update(Allocator &a, const index_tuple<IdxPack...>&, Iterator p, size_type n)
    {
       BOOST_ASSERT(n ==1); (void)n;
-      typename aligned_storage<sizeof(value_type), alignment_of<value_type>::value>::type v;
+      typename dtl::aligned_storage<sizeof(value_type), dtl::alignment_of<value_type>::value>::type v;
       value_type *vp = reinterpret_cast<value_type *>(v.data);
       alloc_traits::construct(a, vp,
          ::boost::forward<Args>(get<IdxPack>(this->args_))...);
@@ -398,7 +398,7 @@ struct insert_emplace_proxy_arg##N\
    void copy_n_and_update(Allocator &a, Iterator p, size_type n)\
    {\
       BOOST_ASSERT(n == 1); (void)n;\
-      typename aligned_storage<sizeof(value_type), alignment_of<value_type>::value>::type v;\
+      typename dtl::aligned_storage<sizeof(value_type), dtl::alignment_of<value_type>::value>::type v;\
       BOOST_ASSERT((((size_type)(&v)) % alignment_of<value_type>::value) == 0);\
       value_type *vp = reinterpret_cast<value_type *>(v.data);\
       alloc_traits::construct(a, vp BOOST_MOVE_I##N BOOST_MOVE_MFWD##N);\

--- a/include/boost/container/detail/flat_tree.hpp
+++ b/include/boost/container/detail/flat_tree.hpp
@@ -922,7 +922,7 @@ class flat_tree
    template <class... Args>
    std::pair<iterator, bool> emplace_unique(BOOST_FWD_REF(Args)... args)
    {
-      typename aligned_storage<sizeof(value_type), alignment_of<value_type>::value>::type v;
+      typename dtl::aligned_storage<sizeof(value_type), dtl::alignment_of<value_type>::value>::type v;
       value_type *pval = reinterpret_cast<value_type *>(v.data);
       get_stored_allocator_noconst_return_t a = this->get_stored_allocator();
       stored_allocator_traits::construct(a, pval, ::boost::forward<Args>(args)... );
@@ -934,7 +934,7 @@ class flat_tree
    iterator emplace_hint_unique(const_iterator hint, BOOST_FWD_REF(Args)... args)
    {
       //hint checked in insert_unique
-      typename aligned_storage<sizeof(value_type), alignment_of<value_type>::value>::type v;
+      typename dtl::aligned_storage<sizeof(value_type), dtl::alignment_of<value_type>::value>::type v;
       value_type *pval = reinterpret_cast<value_type *>(v.data);
       get_stored_allocator_noconst_return_t a = this->get_stored_allocator();
       stored_allocator_traits::construct(a, pval, ::boost::forward<Args>(args)... );
@@ -945,7 +945,7 @@ class flat_tree
    template <class... Args>
    iterator emplace_equal(BOOST_FWD_REF(Args)... args)
    {
-      typename aligned_storage<sizeof(value_type), alignment_of<value_type>::value>::type v;
+      typename dtl::aligned_storage<sizeof(value_type), dtl::alignment_of<value_type>::value>::type v;
       value_type *pval = reinterpret_cast<value_type *>(v.data);
       get_stored_allocator_noconst_return_t a = this->get_stored_allocator();
       stored_allocator_traits::construct(a, pval, ::boost::forward<Args>(args)... );
@@ -957,7 +957,7 @@ class flat_tree
    iterator emplace_hint_equal(const_iterator hint, BOOST_FWD_REF(Args)... args)
    {
       //hint checked in insert_equal
-      typename aligned_storage<sizeof(value_type), alignment_of<value_type>::value>::type v;
+      typename dtl::aligned_storage<sizeof(value_type), dtl::alignment_of<value_type>::value>::type v;
       value_type *pval = reinterpret_cast<value_type *>(v.data);
       get_stored_allocator_noconst_return_t a = this->get_stored_allocator();
       stored_allocator_traits::construct(a, pval, ::boost::forward<Args>(args)... );
@@ -994,7 +994,7 @@ class flat_tree
    BOOST_MOVE_TMPL_LT##N BOOST_MOVE_CLASS##N BOOST_MOVE_GT##N \
    std::pair<iterator, bool> emplace_unique(BOOST_MOVE_UREF##N)\
    {\
-      typename aligned_storage<sizeof(value_type), alignment_of<value_type>::value>::type v;\
+      typename dtl::aligned_storage<sizeof(value_type), dtl::alignment_of<value_type>::value>::type v;\
       value_type *pval = reinterpret_cast<value_type *>(v.data);\
       get_stored_allocator_noconst_return_t a = this->get_stored_allocator();\
       stored_allocator_traits::construct(a, pval BOOST_MOVE_I##N BOOST_MOVE_FWD##N);\
@@ -1005,7 +1005,7 @@ class flat_tree
    BOOST_MOVE_TMPL_LT##N BOOST_MOVE_CLASS##N BOOST_MOVE_GT##N \
    iterator emplace_hint_unique(const_iterator hint BOOST_MOVE_I##N BOOST_MOVE_UREF##N)\
    {\
-      typename aligned_storage<sizeof(value_type), alignment_of<value_type>::value>::type v;\
+      typename dtl::aligned_storage<sizeof(value_type), dtl::alignment_of<value_type>::value>::type v;\
       value_type *pval = reinterpret_cast<value_type *>(v.data);\
       get_stored_allocator_noconst_return_t a = this->get_stored_allocator();\
       stored_allocator_traits::construct(a, pval BOOST_MOVE_I##N BOOST_MOVE_FWD##N);\
@@ -1016,7 +1016,7 @@ class flat_tree
    BOOST_MOVE_TMPL_LT##N BOOST_MOVE_CLASS##N BOOST_MOVE_GT##N \
    iterator emplace_equal(BOOST_MOVE_UREF##N)\
    {\
-      typename aligned_storage<sizeof(value_type), alignment_of<value_type>::value>::type v;\
+      typename dtl::aligned_storage<sizeof(value_type), dtl::alignment_of<value_type>::value>::type v;\
       value_type *pval = reinterpret_cast<value_type *>(v.data);\
       get_stored_allocator_noconst_return_t a = this->get_stored_allocator();\
       stored_allocator_traits::construct(a, pval BOOST_MOVE_I##N BOOST_MOVE_FWD##N);\
@@ -1027,7 +1027,7 @@ class flat_tree
    BOOST_MOVE_TMPL_LT##N BOOST_MOVE_CLASS##N BOOST_MOVE_GT##N \
    iterator emplace_hint_equal(const_iterator hint BOOST_MOVE_I##N BOOST_MOVE_UREF##N)\
    {\
-      typename aligned_storage <sizeof(value_type), alignment_of<value_type>::value>::type v;\
+      typename dtl::aligned_storage <sizeof(value_type), dtl::alignment_of<value_type>::value>::type v;\
       value_type *pval = reinterpret_cast<value_type *>(v.data);\
       get_stored_allocator_noconst_return_t a = this->get_stored_allocator();\
       stored_allocator_traits::construct(a, pval BOOST_MOVE_I##N BOOST_MOVE_FWD##N);\

--- a/include/boost/container/list.hpp
+++ b/include/boost/container/list.hpp
@@ -76,7 +76,7 @@ struct list_node
    typedef T internal_type;
    typedef typename list_hook<VoidPointer>::type hook_type;
 
-   typedef typename aligned_storage<sizeof(T), alignment_of<T>::value>::type storage_t;
+   typedef typename dtl::aligned_storage<sizeof(T), dtl::alignment_of<T>::value>::type storage_t;
    storage_t m_storage;
 
    #if defined(BOOST_GCC) && (BOOST_GCC >= 40600) && (BOOST_GCC < 80000)

--- a/include/boost/container/slist.hpp
+++ b/include/boost/container/slist.hpp
@@ -81,7 +81,7 @@ struct slist_node
    typedef T internal_type;
    typedef typename slist_hook<VoidPointer>::type hook_type;
 
-   typedef typename aligned_storage<sizeof(T), alignment_of<T>::value>::type storage_t;
+   typedef typename dtl::aligned_storage<sizeof(T), dtl::alignment_of<T>::value>::type storage_t;
    storage_t m_storage;
 
    #if defined(BOOST_GCC) && (BOOST_GCC >= 40600) && (BOOST_GCC < 80000)

--- a/include/boost/container/static_vector.hpp
+++ b/include/boost/container/static_vector.hpp
@@ -70,7 +70,7 @@ class static_storage_allocator
    {  return true;  }
 
    private:
-   typename aligned_storage<sizeof(T)*N, alignment_of<T>::value>::type storage;
+   typename dtl::aligned_storage<sizeof(T)*N, dtl::alignment_of<T>::value>::type storage;
 };
 
 }  //namespace dtl {


### PR DESCRIPTION
Workaround for issue https://github.com/boostorg/container/issues/112