### PR TITLE
Use real_allocator to find allocator when rebinding

### DIFF
--- a/include/boost/container/detail/container_rebind.hpp
+++ b/include/boost/container/detail/container_rebind.hpp
@@ -33,14 +33,14 @@ namespace dtl {
    template <template <class, class, class...> class Cont, typename V, typename A, class... An, class U>
    struct container_rebind<Cont<V, A, An...>, U>
    {
-      typedef Cont<U, typename allocator_traits<A>::template portable_rebind_alloc<U>::type, An...> type;
+      typedef Cont<U, typename allocator_traits<typename real_allocator<V, A>::type>::template portable_rebind_alloc<U>::type, An...> type;
    };
 
    //Needed for non-conforming compilers like GCC 4.3
    template <template <class, class> class Cont, typename V, typename A, class U>
    struct container_rebind<Cont<V, A>, U>
    {
-      typedef Cont<U, typename allocator_traits<A>::template portable_rebind_alloc<U>::type> type;
+      typedef Cont<U, typename allocator_traits<typename real_allocator<V, A>::type>::template portable_rebind_alloc<U>::type> type;
    };
 
    template <template <class> class Cont, typename V, class U>
@@ -54,14 +54,14 @@ namespace dtl {
    template <template <class, std::size_t, class, class...> class Cont, typename V, std::size_t N, typename A, class... An, class U>
    struct container_rebind<Cont<V, N, A, An...>, U>
    {
-      typedef Cont<U, N, typename allocator_traits<A>::template portable_rebind_alloc<U>::type, An...> type;
+      typedef Cont<U, N, typename allocator_traits<typename real_allocator<V, A>::type>::template portable_rebind_alloc<U>::type, An...> type;
    };
 
    //Needed for non-conforming compilers like GCC 4.3
    template <template <class, std::size_t, class> class Cont, typename V, std::size_t N, typename A, class U>
    struct container_rebind<Cont<V, N, A>, U>
    {
-      typedef Cont<U, N, typename allocator_traits<A>::template portable_rebind_alloc<U>::type> type;
+      typedef Cont<U, N, typename allocator_traits<typename real_allocator<V, A>::type>::template portable_rebind_alloc<U>::type> type;
    };
 
    template <template <class, std::size_t> class Cont, typename V, std::size_t N, class U>
@@ -85,7 +85,7 @@ namespace dtl {
       , class U>
       struct container_rebind<Cont<V, A>, U>
    {
-      typedef Cont<U, typename allocator_traits<A>::template portable_rebind_alloc<U>::type> type;
+      typedef Cont<U, typename allocator_traits<typename real_allocator<V, A>::type>::template portable_rebind_alloc<U>::type> type;
    };
 
    template <template <class, class, class> class Cont  //1arg
@@ -93,7 +93,7 @@ namespace dtl {
       , class U>
       struct container_rebind<Cont<V, A, P0>, U>
    {
-      typedef Cont<U, typename allocator_traits<A>::template portable_rebind_alloc<U>::type, P0> type;
+      typedef Cont<U, typename allocator_traits<typename real_allocator<V, A>::type>::template portable_rebind_alloc<U>::type, P0> type;
    };
 
    template <template <class, class, class, class> class Cont  //2arg
@@ -101,7 +101,7 @@ namespace dtl {
       , class U>
       struct container_rebind<Cont<V, A, P0, P1>, U>
    {
-      typedef Cont<U, typename allocator_traits<A>::template portable_rebind_alloc<U>::type, P0, P1> type;
+      typedef Cont<U, typename allocator_traits<typename real_allocator<V, A>::type>::template portable_rebind_alloc<U>::type, P0, P1> type;
    };
 
    template <template <class, class, class, class, class> class Cont  //3arg
@@ -109,7 +109,7 @@ namespace dtl {
       , class U>
       struct container_rebind<Cont<V, A, P0, P1, P2>, U>
    {
-      typedef Cont<U, typename allocator_traits<A>::template portable_rebind_alloc<U>::type, P0, P1, P2> type;
+      typedef Cont<U, typename allocator_traits<typename real_allocator<V, A>::type>::template portable_rebind_alloc<U>::type, P0, P1, P2> type;
    };
 
    template <template <class, class, class, class, class, class> class Cont  //4arg
@@ -117,7 +117,7 @@ namespace dtl {
       , class U>
       struct container_rebind<Cont<V, A, P0, P1, P2, P3>, U>
    {
-      typedef Cont<U, typename allocator_traits<A>::template portable_rebind_alloc<U>::type, P0, P1, P2, P3> type;
+      typedef Cont<U, typename allocator_traits<typename real_allocator<V, A>::type>::template portable_rebind_alloc<U>::type, P0, P1, P2, P3> type;
    };
 
    template <template <class, class, class, class, class, class, class> class Cont  //5arg
@@ -125,7 +125,7 @@ namespace dtl {
       , class U>
       struct container_rebind<Cont<V, A, P0, P1, P2, P3, P4>, U>
    {
-      typedef Cont<U, typename allocator_traits<A>::template portable_rebind_alloc<U>::type, P0, P1, P2, P3, P4> type;
+      typedef Cont<U, typename allocator_traits<typename real_allocator<V, A>::type>::template portable_rebind_alloc<U>::type, P0, P1, P2, P3, P4> type;
    };
 
    template <template <class, class, class, class, class, class, class, class> class Cont  //6arg
@@ -133,7 +133,7 @@ namespace dtl {
       , class U>
       struct container_rebind<Cont<V, A, P0, P1, P2, P3, P4, P5>, U>
    {
-      typedef Cont<U, typename allocator_traits<A>::template portable_rebind_alloc<U>::type, P0, P1, P2, P3, P4, P5> type;
+      typedef Cont<U, typename allocator_traits<typename real_allocator<V, A>::type>::template portable_rebind_alloc<U>::type, P0, P1, P2, P3, P4, P5> type;
    };
 
    template <template <class, class, class, class, class, class, class, class, class> class Cont  //7arg
@@ -141,7 +141,7 @@ namespace dtl {
       , class U>
       struct container_rebind<Cont<V, A, P0, P1, P2, P3, P4, P5, P6>, U>
    {
-      typedef Cont<U, typename allocator_traits<A>::template portable_rebind_alloc<U>::type, P0, P1, P2, P3, P4, P5, P6> type;
+      typedef Cont<U, typename allocator_traits<typename real_allocator<V, A>::type>::template portable_rebind_alloc<U>::type, P0, P1, P2, P3, P4, P5, P6> type;
    };
 
    template <template <class, class, class, class, class, class, class, class, class, class> class Cont  //8arg
@@ -149,7 +149,7 @@ namespace dtl {
       , class U>
       struct container_rebind<Cont<V, A, P0, P1, P2, P3, P4, P5, P6, P7>, U>
    {
-      typedef Cont<U, typename allocator_traits<A>::template portable_rebind_alloc<U>::type, P0, P1, P2, P3, P4, P5, P6, P7> type;
+      typedef Cont<U, typename allocator_traits<typename real_allocator<V, A>::type>::template portable_rebind_alloc<U>::type, P0, P1, P2, P3, P4, P5, P6, P7> type;
    };
 
    template <template <class, class, class, class, class, class, class, class, class, class, class> class Cont  //9arg
@@ -157,7 +157,7 @@ namespace dtl {
       , class U>
       struct container_rebind<Cont<V, A, P0, P1, P2, P3, P4, P5, P6, P7, P8>, U>
    {
-      typedef Cont<U, typename allocator_traits<A>::template portable_rebind_alloc<U>::type, P0, P1, P2, P3, P4, P5, P6, P7, P8> type;
+      typedef Cont<U, typename allocator_traits<typename real_allocator<V, A>::type>::template portable_rebind_alloc<U>::type, P0, P1, P2, P3, P4, P5, P6, P7, P8> type;
    };
 
    //For small_vector/static_vector
@@ -174,7 +174,7 @@ namespace dtl {
       , class U>
       struct container_rebind<Cont<V, N, A>, U>
    {
-      typedef Cont<U, N, typename allocator_traits<A>::template portable_rebind_alloc<U>::type> type;
+      typedef Cont<U, N, typename allocator_traits<typename real_allocator<V, A>::type>::template portable_rebind_alloc<U>::type> type;
    };
 
    template <template <class, std::size_t, class, class> class Cont  //1arg
@@ -182,7 +182,7 @@ namespace dtl {
       , class U>
       struct container_rebind<Cont<V, N, A, P0>, U>
    {
-      typedef Cont<U, N, typename allocator_traits<A>::template portable_rebind_alloc<U>::type, P0> type;
+      typedef Cont<U, N, typename allocator_traits<typename real_allocator<V, A>::type>::template portable_rebind_alloc<U>::type, P0> type;
    };
 
    template <template <class, std::size_t, class, class, class> class Cont  //2arg
@@ -190,7 +190,7 @@ namespace dtl {
       , class U>
       struct container_rebind<Cont<V, N, A, P0, P1>, U>
    {
-      typedef Cont<U, N, typename allocator_traits<A>::template portable_rebind_alloc<U>::type, P0, P1> type;
+      typedef Cont<U, N, typename allocator_traits<typename real_allocator<V, A>::type>::template portable_rebind_alloc<U>::type, P0, P1> type;
    };
 
    template <template <class, std::size_t, class, class, class, class> class Cont  //3arg
@@ -198,7 +198,7 @@ namespace dtl {
       , class U>
       struct container_rebind<Cont<V, N, A, P0, P1, P2>, U>
    {
-      typedef Cont<U, N, typename allocator_traits<A>::template portable_rebind_alloc<U>::type, P0, P1, P2> type;
+      typedef Cont<U, N, typename allocator_traits<typename real_allocator<V, A>::type>::template portable_rebind_alloc<U>::type, P0, P1, P2> type;
    };
 
    template <template <class, std::size_t, class, class, class, class, class> class Cont  //4arg
@@ -206,7 +206,7 @@ namespace dtl {
       , class U>
       struct container_rebind<Cont<V, N, A, P0, P1, P2, P3>, U>
    {
-      typedef Cont<U, N, typename allocator_traits<A>::template portable_rebind_alloc<U>::type, P0, P1, P2, P3> type;
+      typedef Cont<U, N, typename allocator_traits<typename real_allocator<V, A>::type>::template portable_rebind_alloc<U>::type, P0, P1, P2, P3> type;
    };
 
    template <template <class, std::size_t, class, class, class, class, class, class> class Cont  //5arg
@@ -214,7 +214,7 @@ namespace dtl {
       , class U>
       struct container_rebind<Cont<V, N, A, P0, P1, P2, P3, P4>, U>
    {
-      typedef Cont<U, N, typename allocator_traits<A>::template portable_rebind_alloc<U>::type, P0, P1, P2, P3, P4> type;
+      typedef Cont<U, N, typename allocator_traits<typename real_allocator<V, A>::type>::template portable_rebind_alloc<U>::type, P0, P1, P2, P3, P4> type;
    };
 
    template <template <class, std::size_t, class, class, class, class, class, class, class> class Cont  //6arg
@@ -222,7 +222,7 @@ namespace dtl {
       , class U>
       struct container_rebind<Cont<V, N, A, P0, P1, P2, P3, P4, P5>, U>
    {
-      typedef Cont<U, N, typename allocator_traits<A>::template portable_rebind_alloc<U>::type, P0, P1, P2, P3, P4, P5> type;
+      typedef Cont<U, N, typename allocator_traits<typename real_allocator<V, A>::type>::template portable_rebind_alloc<U>::type, P0, P1, P2, P3, P4, P5> type;
    };
 
    template <template <class, std::size_t, class, class, class, class, class, class, class, class> class Cont  //7arg
@@ -230,7 +230,7 @@ namespace dtl {
       , class U>
       struct container_rebind<Cont<V, N, A, P0, P1, P2, P3, P4, P5, P6>, U>
    {
-      typedef Cont<U, N, typename allocator_traits<A>::template portable_rebind_alloc<U>::type, P0, P1, P2, P3, P4, P5, P6> type;
+      typedef Cont<U, N, typename allocator_traits<typename real_allocator<V, A>::type>::template portable_rebind_alloc<U>::type, P0, P1, P2, P3, P4, P5, P6> type;
    };
 
    template <template <class, std::size_t, class, class, class, class, class, class, class, class, class> class Cont  //8arg
@@ -238,7 +238,7 @@ namespace dtl {
       , class U>
       struct container_rebind<Cont<V, N, A, P0, P1, P2, P3, P4, P5, P6, P7>, U>
    {
-      typedef Cont<U, N, typename allocator_traits<A>::template portable_rebind_alloc<U>::type, P0, P1, P2, P3, P4, P5, P6, P7> type;
+      typedef Cont<U, N, typename allocator_traits<typename real_allocator<V, A>::type>::template portable_rebind_alloc<U>::type, P0, P1, P2, P3, P4, P5, P6, P7> type;
    };
 
    template <template <class, std::size_t, class, class, class, class, class, class, class, class, class, class> class Cont  //9arg
@@ -246,7 +246,7 @@ namespace dtl {
       , class U>
       struct container_rebind<Cont<V, N, A, P0, P1, P2, P3, P4, P5, P6, P7, P8>, U>
    {
-      typedef Cont<U, N, typename allocator_traits<A>::template portable_rebind_alloc<U>::type, P0, P1, P2, P3, P4, P5, P6, P7, P8> type;
+      typedef Cont<U, N, typename allocator_traits<typename real_allocator<V, A>::type>::template portable_rebind_alloc<U>::type, P0, P1, P2, P3, P4, P5, P6, P7, P8> type;
    };
 
 #endif   //!defined(BOOST_NO_CXX11_VARIADIC_TEMPLATES)

--- a/test/flat_map_test.cpp
+++ b/test/flat_map_test.cpp
@@ -11,6 +11,8 @@
 #include <boost/container/flat_map.hpp>
 #include <boost/container/allocator.hpp>
 #include <boost/container/detail/container_or_allocator_rebind.hpp>
+#include <boost/container/small_vector.hpp>
+#include <boost/container/static_vector.hpp>
 
 #include "print_container.hpp"
 #include "dummy_test_allocator.hpp"
@@ -711,6 +713,32 @@ int main()
       cont_int a; a.insert(cont_int::value_type(0, 9)); a.insert(cont_int::value_type(1, 9)); a.insert(cont_int::value_type(2, 9));
       boost::intrusive::test::test_iterator_random< cont_int >(a);
       if(boost::report_errors() != 0) {
+         return 1;
+      }
+   }
+
+   ////////////////////////////////////
+   //    Testing container implementations
+   ////////////////////////////////////
+   {
+      typedef std::map<int, int>                                     MyStdMap;
+      typedef std::multimap<int, int>                                MyStdMultiMap;
+
+      if (0 != test::map_test
+         < GetMapContainer<small_vector<std::pair<int, int>, 7>>::apply<int>::map_type
+         , MyStdMap
+         , GetMapContainer<small_vector<std::pair<int, int>, 7>>::apply<int>::multimap_type
+         , MyStdMultiMap>()) {
+         std::cout << "Error in map_test<small_vector<std::pair<int, int>, 7>>" << std::endl;
+         return 1;
+      }
+
+      if (0 != test::map_test
+         < GetMapContainer<static_vector<std::pair<int, int>, MaxElem * 10>>::apply<int>::map_type
+         , MyStdMap
+         , GetMapContainer<static_vector<std::pair<int, int>, MaxElem * 10>>::apply<int>::multimap_type
+         , MyStdMultiMap>()) {
+         std::cout << "Error in map_test<static_vector<std::pair<int, int>, MaxElem * 10>>" << std::endl;
          return 1;
       }
    }


### PR DESCRIPTION
After 83bb62fed3aca489e447e394f3b23c272712ecb7 the allocator parameter of
e.g. small_vector can be void. Use real_allocator to convert this to the
actual allocator used by the container.

example (works up to 1.69, breaks in 1.70):

    #include <boost/container/flat_map.hpp>
    #include <boost/container/small_vector.hpp>
    boost::container::flat_map<int, int, std::less<>,
        boost::container::small_vector<std::pair<int, int>, 7>> m;