### PR TITLE
Fix has_trivial_destructor_after_move

### DIFF
--- a/include/boost/container/deque.hpp
+++ b/include/boost/container/deque.hpp
@@ -2295,8 +2295,9 @@ namespace boost {
 template <class T, class Allocator, class Options>
 struct has_trivial_destructor_after_move<boost::container::deque<T, Allocator, Options> >
 {
-   typedef typename ::boost::container::allocator_traits<Allocator>::pointer pointer;
-   static const bool value = ::boost::has_trivial_destructor_after_move<Allocator>::value &&
+   typedef typename boost::container::deque<T, Allocator, Options>::allocator_type allocator_type;
+   typedef typename ::boost::container::allocator_traits<allocator_type>::pointer pointer;
+   static const bool value = ::boost::has_trivial_destructor_after_move<allocator_type>::value &&
                              ::boost::has_trivial_destructor_after_move<pointer>::value;
 };
 

--- a/include/boost/container/detail/flat_tree.hpp
+++ b/include/boost/container/detail/flat_tree.hpp
@@ -1622,11 +1622,11 @@ template <class T, class KeyOfValue,
 class Compare, class AllocatorOrContainer>
 struct has_trivial_destructor_after_move<boost::container::dtl::flat_tree<T, KeyOfValue, Compare, AllocatorOrContainer> >
 {
-   typedef typename boost::container::dtl::select_container_type<T, AllocatorOrContainer>::type container_type;
-   typedef typename container_type::allocator_type allocator_t;
-   typedef typename ::boost::container::allocator_traits<allocator_t>::pointer pointer;
-   static const bool value = ::boost::has_trivial_destructor_after_move<allocator_t>::value &&
-                             ::boost::has_trivial_destructor_after_move<pointer>::value;
+   typedef boost::container::dtl::flat_tree<T, KeyOfValue, Compare, AllocatorOrContainer> flat_tree;
+   typedef typename flat_tree::container_type container_type;
+   typedef typename flat_tree::key_compare key_compare;
+   static const bool value = ::boost::has_trivial_destructor_after_move<container_type>::value &&
+                             ::boost::has_trivial_destructor_after_move<key_compare>::value;
 };
 
 }  //namespace boost {

--- a/include/boost/container/detail/tree.hpp
+++ b/include/boost/container/detail/tree.hpp
@@ -1516,8 +1516,9 @@ struct has_trivial_destructor_after_move
          <T, KeyOfValue, Compare, Allocator, Options>
    >
 {
-   typedef typename ::boost::container::allocator_traits<Allocator>::pointer pointer;
-   static const bool value = ::boost::has_trivial_destructor_after_move<Allocator>::value &&
+   typedef typename ::boost::container::dtl::tree<T, KeyOfValue, Compare, Allocator, Options>::allocator_type allocator_type;
+   typedef typename ::boost::container::allocator_traits<allocator_type>::pointer pointer;
+   static const bool value = ::boost::has_trivial_destructor_after_move<allocator_type>::value &&
                              ::boost::has_trivial_destructor_after_move<pointer>::value &&
                              ::boost::has_trivial_destructor_after_move<Compare>::value;
 };

--- a/include/boost/container/flat_map.hpp
+++ b/include/boost/container/flat_map.hpp
@@ -1651,10 +1651,10 @@ flat_map(ordered_unique_range_t, InputIterator, InputIterator, Compare const&, A
 template <class Key, class T, class Compare, class AllocatorOrContainer>
 struct has_trivial_destructor_after_move<boost::container::flat_map<Key, T, Compare, AllocatorOrContainer> >
 {
-   typedef typename ::boost::container::allocator_traits<AllocatorOrContainer>::pointer pointer;
-   static const bool value = ::boost::has_trivial_destructor_after_move<AllocatorOrContainer>::value &&
-                             ::boost::has_trivial_destructor_after_move<pointer>::value &&
-                             ::boost::has_trivial_destructor_after_move<Compare>::value;
+   typedef ::boost::container::dtl::pair<Key, T> value_t;
+   typedef typename ::boost::container::dtl::container_or_allocator_rebind<AllocatorOrContainer, value_t>::type alloc_or_cont_t;
+   typedef ::boost::container::dtl::flat_tree<value_t,::boost::container::dtl::select1st<Key>, Compare, alloc_or_cont_t> tree;
+   static const bool value = ::boost::has_trivial_destructor_after_move<tree>::value;
 };
 
 namespace container {
@@ -2961,10 +2961,10 @@ namespace boost {
 template <class Key, class T, class Compare, class AllocatorOrContainer>
 struct has_trivial_destructor_after_move< boost::container::flat_multimap<Key, T, Compare, AllocatorOrContainer> >
 {
-   typedef typename ::boost::container::allocator_traits<AllocatorOrContainer>::pointer pointer;
-   static const bool value = ::boost::has_trivial_destructor_after_move<AllocatorOrContainer>::value &&
-                             ::boost::has_trivial_destructor_after_move<pointer>::value &&
-                             ::boost::has_trivial_destructor_after_move<Compare>::value;
+   typedef ::boost::container::dtl::pair<Key, T> value_t;
+   typedef typename ::boost::container::dtl::container_or_allocator_rebind<AllocatorOrContainer, value_t>::type alloc_or_cont_t;
+   typedef ::boost::container::dtl::flat_tree<value_t,::boost::container::dtl::select1st<Key>, Compare, alloc_or_cont_t> tree;
+   static const bool value = ::boost::has_trivial_destructor_after_move<tree>::value;
 };
 
 }  //namespace boost {

--- a/include/boost/container/flat_set.hpp
+++ b/include/boost/container/flat_set.hpp
@@ -1192,10 +1192,8 @@ flat_set(ordered_unique_range_t, InputIterator, InputIterator, Compare const&, A
 template <class Key, class Compare, class AllocatorOrContainer>
 struct has_trivial_destructor_after_move<boost::container::flat_set<Key, Compare, AllocatorOrContainer> >
 {
-   typedef typename ::boost::container::allocator_traits<AllocatorOrContainer>::pointer pointer;
-   static const bool value = ::boost::has_trivial_destructor_after_move<AllocatorOrContainer>::value &&
-                             ::boost::has_trivial_destructor_after_move<pointer>::value &&
-                             ::boost::has_trivial_destructor_after_move<Compare>::value;
+   typedef ::boost::container::dtl::flat_tree<Key, ::boost::container::dtl::identity<Key>, Compare, AllocatorOrContainer> tree;
+   static const bool value = ::boost::has_trivial_destructor_after_move<tree>::value;
 };
 
 namespace container {
@@ -1926,10 +1924,8 @@ flat_multiset(ordered_range_t, InputIterator, InputIterator, Compare const&, All
 template <class Key, class Compare, class AllocatorOrContainer>
 struct has_trivial_destructor_after_move<boost::container::flat_multiset<Key, Compare, AllocatorOrContainer> >
 {
-   typedef typename ::boost::container::allocator_traits<AllocatorOrContainer>::pointer pointer;
-   static const bool value = ::boost::has_trivial_destructor_after_move<AllocatorOrContainer>::value &&
-                             ::boost::has_trivial_destructor_after_move<pointer>::value &&
-                             ::boost::has_trivial_destructor_after_move<Compare>::value;
+   typedef ::boost::container::dtl::flat_tree<Key, ::boost::container::dtl::identity<Key>, Compare, AllocatorOrContainer> tree;
+   static const bool value = ::boost::has_trivial_destructor_after_move<tree>::value;
 };
 
 namespace container {

--- a/include/boost/container/list.hpp
+++ b/include/boost/container/list.hpp
@@ -1522,8 +1522,9 @@ list(InputIterator, InputIterator, ValueAllocator const&) ->
 template <class T, class Allocator>
 struct has_trivial_destructor_after_move<boost::container::list<T, Allocator> >
 {
-   typedef typename ::boost::container::allocator_traits<Allocator>::pointer pointer;
-   static const bool value = ::boost::has_trivial_destructor_after_move<Allocator>::value &&
+   typedef typename boost::container::list<T, Allocator>::allocator_type allocator_type;
+   typedef typename ::boost::container::allocator_traits<allocator_type>::pointer pointer;
+   static const bool value = ::boost::has_trivial_destructor_after_move<allocator_type>::value &&
                              ::boost::has_trivial_destructor_after_move<pointer>::value;
 };
 

--- a/include/boost/container/map.hpp
+++ b/include/boost/container/map.hpp
@@ -1366,13 +1366,11 @@ map(ordered_unique_range_t, InputIterator, InputIterator, Compare const&, Alloca
 
 //!has_trivial_destructor_after_move<> == true_type
 //!specialization for optimizations
-template <class Key, class T, class Compare, class Allocator>
-struct has_trivial_destructor_after_move<boost::container::map<Key, T, Compare, Allocator> >
+template <class Key, class T, class Compare, class Allocator, class Options>
+struct has_trivial_destructor_after_move<boost::container::map<Key, T, Compare, Allocator, Options> >
 {
-   typedef typename ::boost::container::allocator_traits<Allocator>::pointer pointer;
-   static const bool value = ::boost::has_trivial_destructor_after_move<Allocator>::value &&
-                             ::boost::has_trivial_destructor_after_move<pointer>::value &&
-                             ::boost::has_trivial_destructor_after_move<Compare>::value;
+   typedef ::boost::container::dtl::tree<std::pair<const Key, T>, int, Compare, Allocator, Options> tree;
+   static const bool value = ::boost::has_trivial_destructor_after_move<tree>::value;
 };
 
 namespace container {
@@ -2292,13 +2290,11 @@ multimap(ordered_range_t, InputIterator, InputIterator, Compare const&, Allocato
 
 //!has_trivial_destructor_after_move<> == true_type
 //!specialization for optimizations
-template <class Key, class T, class Compare, class Allocator>
-struct has_trivial_destructor_after_move<boost::container::multimap<Key, T, Compare, Allocator> >
+template <class Key, class T, class Compare, class Allocator, class Options>
+struct has_trivial_destructor_after_move<boost::container::multimap<Key, T, Compare, Allocator, Options> >
 {
-   typedef typename ::boost::container::allocator_traits<Allocator>::pointer pointer;
-   static const bool value = ::boost::has_trivial_destructor_after_move<Allocator>::value &&
-                             ::boost::has_trivial_destructor_after_move<pointer>::value &&
-                             ::boost::has_trivial_destructor_after_move<Compare>::value;
+   typedef ::boost::container::dtl::tree<std::pair<const Key, T>, int, Compare, Allocator, Options> tree;
+   static const bool value = ::boost::has_trivial_destructor_after_move<tree>::value;
 };
 
 namespace container {

--- a/include/boost/container/set.hpp
+++ b/include/boost/container/set.hpp
@@ -1024,13 +1024,11 @@ set(ordered_unique_range_t, InputIterator, InputIterator, Compare const&, Alloca
 
 //!has_trivial_destructor_after_move<> == true_type
 //!specialization for optimizations
-template <class Key, class Compare, class Options, class Allocator>
+template <class Key, class Compare, class Allocator, class Options>
 struct has_trivial_destructor_after_move<boost::container::set<Key, Compare, Allocator, Options> >
 {
-   typedef typename ::boost::container::allocator_traits<Allocator>::pointer pointer;
-   static const bool value = ::boost::has_trivial_destructor_after_move<Allocator>::value &&
-                             ::boost::has_trivial_destructor_after_move<pointer>::value &&
-                             ::boost::has_trivial_destructor_after_move<Compare>::value;
+   typedef ::boost::container::dtl::tree<Key, void, Compare, Allocator, Options> tree;
+   static const bool value = ::boost::has_trivial_destructor_after_move<tree>::value;
 };
 
 namespace container {
@@ -1693,10 +1691,8 @@ multiset(ordered_range_t, InputIterator, InputIterator, Compare const&, Allocato
 template <class Key, class Compare, class Allocator, class Options>
 struct has_trivial_destructor_after_move<boost::container::multiset<Key, Compare, Allocator, Options> >
 {
-   typedef typename ::boost::container::allocator_traits<Allocator>::pointer pointer;
-   static const bool value = ::boost::has_trivial_destructor_after_move<Allocator>::value &&
-                             ::boost::has_trivial_destructor_after_move<pointer>::value &&
-                             ::boost::has_trivial_destructor_after_move<Compare>::value;
+   typedef ::boost::container::dtl::tree<Key, void, Compare, Allocator, Options> tree;
+   static const bool value = ::boost::has_trivial_destructor_after_move<tree>::value;
 };
 
 namespace container {

--- a/include/boost/container/slist.hpp
+++ b/include/boost/container/slist.hpp
@@ -1696,8 +1696,9 @@ namespace boost {
 template <class T, class Allocator>
 struct has_trivial_destructor_after_move<boost::container::slist<T, Allocator> >
 {
-   typedef typename ::boost::container::allocator_traits<Allocator>::pointer pointer;
-   static const bool value = ::boost::has_trivial_destructor_after_move<Allocator>::value &&
+   typedef typename boost::container::slist<T, Allocator>::allocator_type allocator_type;
+   typedef typename ::boost::container::allocator_traits<allocator_type>::pointer pointer;
+   static const bool value = ::boost::has_trivial_destructor_after_move<allocator_type>::value &&
                              ::boost::has_trivial_destructor_after_move<pointer>::value;
 };
 

--- a/include/boost/container/stable_vector.hpp
+++ b/include/boost/container/stable_vector.hpp
@@ -2183,8 +2183,9 @@ stable_vector(InputIterator, InputIterator, Allocator const&) ->
 template <class T, class Allocator>
 struct has_trivial_destructor_after_move<boost::container::stable_vector<T, Allocator> >
 {
-   typedef typename ::boost::container::allocator_traits<Allocator>::pointer pointer;
-   static const bool value = ::boost::has_trivial_destructor_after_move<Allocator>::value &&
+   typedef typename boost::container::stable_vector<T, Allocator>::allocator_type allocator_type;
+   typedef typename ::boost::container::allocator_traits<allocator_type>::pointer pointer;
+   static const bool value = ::boost::has_trivial_destructor_after_move<allocator_type>::value &&
                              ::boost::has_trivial_destructor_after_move<pointer>::value;
 };
 

--- a/include/boost/container/string.hpp
+++ b/include/boost/container/string.hpp
@@ -3490,9 +3490,9 @@ namespace boost {
 template <class C, class T, class Allocator>
 struct has_trivial_destructor_after_move<boost::container::basic_string<C, T, Allocator> >
 {
-   typedef typename ::boost::container::allocator_traits
-      <typename boost::container::basic_string<C, T, Allocator>::allocator_type>::pointer pointer;
-   static const bool value = ::boost::has_trivial_destructor_after_move<Allocator>::value &&
+   typedef typename boost::container::basic_string<C, T, Allocator>::allocator_type allocator_type;
+   typedef typename ::boost::container::allocator_traits<allocator_type>::pointer pointer;
+   static const bool value = ::boost::has_trivial_destructor_after_move<allocator_type>::value &&
                              ::boost::has_trivial_destructor_after_move<pointer>::value;
 };
 

--- a/include/boost/container/vector.hpp
+++ b/include/boost/container/vector.hpp
@@ -3413,9 +3413,9 @@ namespace boost {
 template <class T, class Allocator, class Options>
 struct has_trivial_destructor_after_move<boost::container::vector<T, Allocator, Options> >
 {
-   typedef typename ::boost::container::allocator_traits
-      <typename boost::container::real_allocator<T, Allocator>::type>::pointer pointer;
-   static const bool value = ::boost::has_trivial_destructor_after_move<Allocator>::value &&
+   typedef typename boost::container::vector<T, Allocator, Options>::allocator_type allocator_type;
+   typedef typename ::boost::container::allocator_traits<allocator_type>::pointer pointer;
+   static const bool value = ::boost::has_trivial_destructor_after_move<allocator_type>::value &&
                              ::boost::has_trivial_destructor_after_move<pointer>::value;
 };
 

--- a/test/deque_test.cpp
+++ b/test/deque_test.cpp
@@ -412,6 +412,34 @@ int main ()
       }
    }
 
+   ////////////////////////////////////
+   //    has_trivial_destructor_after_move testing
+   ////////////////////////////////////
+   // default allocator
+   {
+      typedef boost::container::deque<int> cont;
+      typedef cont::allocator_type allocator_type;
+      typedef boost::container::allocator_traits<allocator_type>::pointer pointer;
+      if (boost::has_trivial_destructor_after_move<cont>::value !=
+          boost::has_trivial_destructor_after_move<allocator_type>::value &&
+          boost::has_trivial_destructor_after_move<pointer>::value) {
+         std::cerr << "has_trivial_destructor_after_move(default allocator) test failed" << std::endl;
+         return 1;
+      }
+   }
+   // std::allocator
+   {
+      typedef boost::container::deque<int, std::allocator<int> > cont;
+      typedef cont::allocator_type allocator_type;
+      typedef boost::container::allocator_traits<allocator_type>::pointer pointer;
+      if (boost::has_trivial_destructor_after_move<cont>::value !=
+          boost::has_trivial_destructor_after_move<allocator_type>::value &&
+          boost::has_trivial_destructor_after_move<pointer>::value) {
+         std::cerr << "has_trivial_destructor_after_move(std::allocator) test failed" << std::endl;
+         return 1;
+      }
+   }
+
    return 0;
 }
 

--- a/test/flat_map_test.cpp
+++ b/test/flat_map_test.cpp
@@ -8,6 +8,9 @@
 //
 //////////////////////////////////////////////////////////////////////////////
 #include <boost/container/detail/config_begin.hpp>
+
+#include <vector>
+
 #include <boost/container/flat_map.hpp>
 #include <boost/container/allocator.hpp>
 #include <boost/container/detail/container_or_allocator_rebind.hpp>
@@ -712,6 +715,80 @@ int main()
       boost::intrusive::test::test_iterator_random< cont_int >(a);
       if(boost::report_errors() != 0) {
          return 1;
+      }
+   }
+
+   ////////////////////////////////////
+   //    has_trivial_destructor_after_move testing
+   ////////////////////////////////////
+   {
+      typedef boost::container::dtl::pair<int, int> value_t;
+      typedef boost::container::dtl::select1st<int> key_of_value_t;
+      // flat_map, default
+      {
+         typedef boost::container::new_allocator<value_t> alloc_or_cont_t;
+         typedef boost::container::flat_map<int, int> cont;
+         typedef boost::container::dtl::flat_tree<value_t, key_of_value_t, std::less<int>, alloc_or_cont_t> tree;
+         if (boost::has_trivial_destructor_after_move<cont>::value !=
+             boost::has_trivial_destructor_after_move<tree>::value) {
+            std::cerr << "has_trivial_destructor_after_move(flat_map, default) test failed" << std::endl;
+            return 1;
+         }
+      }
+      // flat_map, vector
+      {
+         typedef boost::container::vector<value_t> alloc_or_cont_t;
+         typedef boost::container::flat_map<int, int, std::less<int>, alloc_or_cont_t> cont;
+         typedef boost::container::dtl::flat_tree<value_t, key_of_value_t, std::less<int>, alloc_or_cont_t> tree;
+         if (boost::has_trivial_destructor_after_move<cont>::value !=
+             boost::has_trivial_destructor_after_move<tree>::value) {
+            std::cerr << "has_trivial_destructor_after_move(flat_map, vector) test failed" << std::endl;
+            return 1;
+         }
+      }
+      // flat_map, std::vector
+      {
+         typedef std::vector<value_t> alloc_or_cont_t;
+         typedef boost::container::flat_map<int, int, std::less<int>, alloc_or_cont_t> cont;
+         typedef boost::container::dtl::flat_tree<value_t, key_of_value_t, std::less<int>, alloc_or_cont_t> tree;
+         if (boost::has_trivial_destructor_after_move<cont>::value !=
+             boost::has_trivial_destructor_after_move<tree>::value) {
+            std::cerr << "has_trivial_destructor_after_move(flat_map, std::vector) test failed" << std::endl;
+            return 1;
+         }
+      }
+      // flat_multimap, default
+      {
+         typedef boost::container::new_allocator<value_t> alloc_or_cont_t;
+         typedef boost::container::flat_multimap<int, int> cont;
+         typedef boost::container::dtl::flat_tree<value_t, key_of_value_t, std::less<int>, alloc_or_cont_t> tree;
+         if (boost::has_trivial_destructor_after_move<cont>::value !=
+             boost::has_trivial_destructor_after_move<tree>::value) {
+            std::cerr << "has_trivial_destructor_after_move(flat_multimap, default) test failed" << std::endl;
+            return 1;
+         }
+      }
+      // flat_multimap, vector
+      {
+         typedef boost::container::vector<value_t> alloc_or_cont_t;
+         typedef boost::container::flat_multimap<int, int, std::less<int>, alloc_or_cont_t> cont;
+         typedef boost::container::dtl::flat_tree<value_t, key_of_value_t, std::less<int>, alloc_or_cont_t> tree;
+         if (boost::has_trivial_destructor_after_move<cont>::value !=
+             boost::has_trivial_destructor_after_move<tree>::value) {
+            std::cerr << "has_trivial_destructor_after_move(flat_multimap, vector) test failed" << std::endl;
+            return 1;
+         }
+      }
+      // flat_multimap, std::vector
+      {
+         typedef std::vector<value_t> alloc_or_cont_t;
+         typedef boost::container::flat_multimap<int, int, std::less<int>, alloc_or_cont_t> cont;
+         typedef boost::container::dtl::flat_tree<value_t, key_of_value_t, std::less<int>, alloc_or_cont_t> tree;
+         if (boost::has_trivial_destructor_after_move<cont>::value !=
+             boost::has_trivial_destructor_after_move<tree>::value) {
+            std::cerr << "has_trivial_destructor_after_move(flat_multimap, std::vector) test failed" << std::endl;
+            return 1;
+         }
       }
    }
 

--- a/test/flat_set_test.cpp
+++ b/test/flat_set_test.cpp
@@ -10,7 +10,9 @@
 
 #include <boost/container/detail/config_begin.hpp>
 
+#include <iostream>
 #include <set>
+#include <vector>
 
 #include <boost/container/flat_set.hpp>
 #include <boost/container/detail/container_or_allocator_rebind.hpp>
@@ -810,6 +812,77 @@ int main()
       boost::intrusive::test::test_iterator_random< cont_int >(a);
       if(boost::report_errors() != 0) {
          return 1;
+      }
+   }
+
+   ////////////////////////////////////
+   //    has_trivial_destructor_after_move testing
+   ////////////////////////////////////
+   {
+      typedef boost::container::dtl::identity<int> key_of_value_t;
+      // flat_set, default
+      {
+         typedef boost::container::flat_set<int> cont;
+         typedef boost::container::dtl::flat_tree<int, key_of_value_t, std::less<int>, void> tree;
+         if (boost::has_trivial_destructor_after_move<cont>::value !=
+             boost::has_trivial_destructor_after_move<tree>::value) {
+            std::cerr << "has_trivial_destructor_after_move(flat_set, default) test failed" << std::endl;
+            return 1;
+         }
+      }
+      // flat_set, vector
+      {
+         typedef boost::container::vector<int> alloc_or_cont_t;
+         typedef boost::container::flat_set<int, std::less<int>, alloc_or_cont_t> cont;
+         typedef boost::container::dtl::flat_tree<int, key_of_value_t, std::less<int>, alloc_or_cont_t> tree;
+         if (boost::has_trivial_destructor_after_move<cont>::value !=
+             boost::has_trivial_destructor_after_move<tree>::value) {
+            std::cerr << "has_trivial_destructor_after_move(flat_set, vector) test failed" << std::endl;
+            return 1;
+         }
+      }
+      // flat_set, std::vector
+      {
+         typedef std::vector<int> alloc_or_cont_t;
+         typedef boost::container::flat_set<int, std::less<int>, alloc_or_cont_t> cont;
+         typedef boost::container::dtl::flat_tree<int, key_of_value_t, std::less<int>, alloc_or_cont_t> tree;
+         if (boost::has_trivial_destructor_after_move<cont>::value !=
+             boost::has_trivial_destructor_after_move<tree>::value) {
+            std::cerr << "has_trivial_destructor_after_move(flat_set, std::vector) test failed" << std::endl;
+            return 1;
+         }
+      }
+      // flat_multiset, default
+      {
+         typedef boost::container::flat_multiset<int> cont;
+         typedef boost::container::dtl::flat_tree<int, key_of_value_t, std::less<int>, void> tree;
+         if (boost::has_trivial_destructor_after_move<cont>::value !=
+             boost::has_trivial_destructor_after_move<tree>::value) {
+            std::cerr << "has_trivial_destructor_after_move(flat_multiset, default) test failed" << std::endl;
+            return 1;
+         }
+      }
+      // flat_multiset, vector
+      {
+         typedef boost::container::vector<int> alloc_or_cont_t;
+         typedef boost::container::flat_multiset<int, std::less<int>, alloc_or_cont_t> cont;
+         typedef boost::container::dtl::flat_tree<int, key_of_value_t, std::less<int>, alloc_or_cont_t> tree;
+         if (boost::has_trivial_destructor_after_move<cont>::value !=
+             boost::has_trivial_destructor_after_move<tree>::value) {
+            std::cerr << "has_trivial_destructor_after_move(flat_multiset, vector) test failed" << std::endl;
+            return 1;
+         }
+      }
+      // flat_multiset, std::vector
+      {
+         typedef std::vector<int> alloc_or_cont_t;
+         typedef boost::container::flat_multiset<int, std::less<int>, alloc_or_cont_t> cont;
+         typedef boost::container::dtl::flat_tree<int, key_of_value_t, std::less<int>, alloc_or_cont_t> tree;
+         if (boost::has_trivial_destructor_after_move<cont>::value !=
+             boost::has_trivial_destructor_after_move<tree>::value) {
+            std::cerr << "has_trivial_destructor_after_move(flat_multiset, std::vector) test failed" << std::endl;
+            return 1;
+         }
       }
    }
 

--- a/test/flat_tree_test.cpp
+++ b/test/flat_tree_test.cpp
@@ -12,6 +12,8 @@
 #include <boost/container/stable_vector.hpp>
 #include <boost/container/static_vector.hpp>
 
+#include <iostream>
+
 #include "movable_int.hpp"
 #include "dummy_test_allocator.hpp"
 
@@ -120,5 +122,35 @@ template class flat_tree
 
 int main ()
 {
+   ////////////////////////////////////
+   //    has_trivial_destructor_after_move testing
+   ////////////////////////////////////
+   // default
+   {
+      typedef boost::container::dtl::flat_tree<int, boost::container::dtl::identity<int>,
+              std::less<int>, void> tree;
+      typedef tree::container_type container_type;
+      typedef tree::key_compare key_compare;
+      if (boost::has_trivial_destructor_after_move<tree>::value !=
+          boost::has_trivial_destructor_after_move<container_type>::value &&
+          boost::has_trivial_destructor_after_move<key_compare>::value) {
+         std::cerr << "has_trivial_destructor_after_move(default allocator) test failed" << std::endl;
+         return 1;
+      }
+   }
+   // std::allocator
+   {
+      typedef boost::container::dtl::flat_tree<int, boost::container::dtl::identity<int>,
+              std::less<int>, std::allocator<int> > tree;
+      typedef tree::container_type container_type;
+      typedef tree::key_compare key_compare;
+      if (boost::has_trivial_destructor_after_move<tree>::value !=
+          boost::has_trivial_destructor_after_move<container_type>::value &&
+          boost::has_trivial_destructor_after_move<key_compare>::value) {
+         std::cerr << "has_trivial_destructor_after_move(std::allocator) test failed" << std::endl;
+         return 1;
+      }
+   }
+
    return 0;
 }

--- a/test/list_test.cpp
+++ b/test/list_test.cpp
@@ -252,6 +252,34 @@ int main ()
    }
 #endif
 
+   ////////////////////////////////////
+   //    has_trivial_destructor_after_move testing
+   ////////////////////////////////////
+   // default allocator
+   {
+      typedef boost::container::list<int> cont;
+      typedef cont::allocator_type allocator_type;
+      typedef boost::container::allocator_traits<allocator_type>::pointer pointer;
+      if (boost::has_trivial_destructor_after_move<cont>::value !=
+          boost::has_trivial_destructor_after_move<allocator_type>::value &&
+          boost::has_trivial_destructor_after_move<pointer>::value) {
+         std::cerr << "has_trivial_destructor_after_move(default allocator) test failed" << std::endl;
+         return 1;
+      }
+   }
+   // std::allocator
+   {
+      typedef boost::container::list<int, std::allocator<int> > cont;
+      typedef cont::allocator_type allocator_type;
+      typedef boost::container::allocator_traits<allocator_type>::pointer pointer;
+      if (boost::has_trivial_destructor_after_move<cont>::value !=
+          boost::has_trivial_destructor_after_move<allocator_type>::value &&
+          boost::has_trivial_destructor_after_move<pointer>::value) {
+         std::cerr << "has_trivial_destructor_after_move(std::allocator) test failed" << std::endl;
+         return 1;
+      }
+   }
+
    return 0;
 }
 

--- a/test/map_test.cpp
+++ b/test/map_test.cpp
@@ -633,6 +633,60 @@ int main ()
    BOOST_STATIC_ASSERT(sizeof(rbmmap_size_optimized_yes) < sizeof(rbmap_size_optimized_no));
    BOOST_STATIC_ASSERT(sizeof(avlmap_size_optimized_yes) < sizeof(avlmmap_size_optimized_no));
 
+   ////////////////////////////////////
+   //    has_trivial_destructor_after_move testing
+   ////////////////////////////////////
+   {
+      typedef std::pair<const int, int> value_type;
+      //
+      // map
+      //
+      // default allocator
+      {
+         typedef boost::container::map<int, int> cont;
+         typedef boost::container::dtl::tree<value_type, int, std::less<int>, void, void> tree;
+         if (boost::has_trivial_destructor_after_move<cont>::value !=
+             boost::has_trivial_destructor_after_move<tree>::value) {
+            std::cerr << "has_trivial_destructor_after_move(map, default allocator) test failed" << std::endl;
+            return 1;
+         }
+      }
+      // std::allocator
+      {
+         typedef boost::container::map<int, int, std::less<int>, std::allocator<value_type> > cont;
+         typedef boost::container::dtl::tree<value_type, int, std::less<int>, std::allocator<value_type>, void> tree;
+         if (boost::has_trivial_destructor_after_move<cont>::value !=
+             boost::has_trivial_destructor_after_move<tree>::value) {
+            std::cerr << "has_trivial_destructor_after_move(map, std::allocator) test failed" << std::endl;
+            return 1;
+         }
+      }
+      //
+      // multimap
+      //
+      // default allocator
+      {
+         //       default allocator
+         typedef boost::container::multimap<int, int> cont;
+         typedef boost::container::dtl::tree<value_type, int, std::less<int>, void, void> tree;
+         if (boost::has_trivial_destructor_after_move<cont>::value !=
+             boost::has_trivial_destructor_after_move<tree>::value) {
+            std::cerr << "has_trivial_destructor_after_move(multimap, default allocator) test failed" << std::endl;
+            return 1;
+         }
+      }
+      // std::allocator
+      {
+         typedef boost::container::multimap<int, int, std::less<int>, std::allocator<value_type> > cont;
+         typedef boost::container::dtl::tree<value_type, int, std::less<int>, std::allocator<value_type>, void> tree;
+         if (boost::has_trivial_destructor_after_move<cont>::value !=
+             boost::has_trivial_destructor_after_move<tree>::value) {
+            std::cerr << "has_trivial_destructor_after_move(multimap, std::allocator) test failed" << std::endl;
+            return 1;
+         }
+      }
+   }
+
    return 0;
 }
 

--- a/test/set_test.cpp
+++ b/test/set_test.cpp
@@ -605,6 +605,50 @@ int main ()
    if(!node_type_test())
       return 1;
 
+   ////////////////////////////////////
+   //    has_trivial_destructor_after_move testing
+   ////////////////////////////////////
+   // set, default allocator
+   {
+      typedef boost::container::set<int> cont;
+      typedef boost::container::dtl::tree<int, void, std::less<int>, void, void> tree;
+      if (boost::has_trivial_destructor_after_move<cont>::value !=
+          boost::has_trivial_destructor_after_move<tree>::value) {
+         std::cerr << "has_trivial_destructor_after_move(set, default allocator) test failed" << std::endl;
+         return 1;
+      }
+   }
+   // set, std::allocator
+   {
+      typedef boost::container::set<int, std::less<int>, std::allocator<int> > cont;
+      typedef boost::container::dtl::tree<int, void, std::less<int>, std::allocator<int>, void> tree;
+      if (boost::has_trivial_destructor_after_move<cont>::value !=
+          boost::has_trivial_destructor_after_move<tree>::value) {
+         std::cerr << "has_trivial_destructor_after_move(set, std::allocator) test failed" << std::endl;
+         return 1;
+      }
+   }
+   // multiset, default allocator
+   {
+      typedef boost::container::multiset<int> cont;
+      typedef boost::container::dtl::tree<int, void, std::less<int>, void, void> tree;
+      if (boost::has_trivial_destructor_after_move<cont>::value !=
+          boost::has_trivial_destructor_after_move<tree>::value) {
+         std::cerr << "has_trivial_destructor_after_move(multiset, default allocator) test failed" << std::endl;
+         return 1;
+      }
+   }
+   // multiset, std::allocator
+   {
+      typedef boost::container::multiset<int, std::less<int>, std::allocator<int> > cont;
+      typedef boost::container::dtl::tree<int, void, std::less<int>, std::allocator<int>, void> tree;
+      if (boost::has_trivial_destructor_after_move<cont>::value !=
+          boost::has_trivial_destructor_after_move<tree>::value) {
+         std::cerr << "has_trivial_destructor_after_move(multiset, std::allocator) test failed" << std::endl;
+         return 1;
+      }
+   }
+
    return 0;
 }
 

--- a/test/slist_test.cpp
+++ b/test/slist_test.cpp
@@ -255,6 +255,34 @@ int main ()
    }
 #endif
 
+   ////////////////////////////////////
+   //    has_trivial_destructor_after_move testing
+   ////////////////////////////////////
+   // default allocator
+   {
+      typedef boost::container::slist<int> cont;
+      typedef cont::allocator_type allocator_type;
+      typedef boost::container::allocator_traits<allocator_type>::pointer pointer;
+      if (boost::has_trivial_destructor_after_move<cont>::value !=
+          boost::has_trivial_destructor_after_move<allocator_type>::value &&
+          boost::has_trivial_destructor_after_move<pointer>::value) {
+         std::cerr << "has_trivial_destructor_after_move(default allocator) test failed" << std::endl;
+         return 1;
+      }
+   }
+   // std::allocator
+   {
+      typedef boost::container::slist<int, std::allocator<int> > cont;
+      typedef cont::allocator_type allocator_type;
+      typedef boost::container::allocator_traits<allocator_type>::pointer pointer;
+      if (boost::has_trivial_destructor_after_move<cont>::value !=
+          boost::has_trivial_destructor_after_move<allocator_type>::value &&
+          boost::has_trivial_destructor_after_move<pointer>::value) {
+         std::cerr << "has_trivial_destructor_after_move(std::allocator) test failed" << std::endl;
+         return 1;
+      }
+   }
+
    return 0;
 }
 

--- a/test/small_vector_test.cpp
+++ b/test/small_vector_test.cpp
@@ -212,5 +212,25 @@ int main()
       }
    }
 
+   ////////////////////////////////////
+   //    has_trivial_destructor_after_move testing
+   ////////////////////////////////////
+   // default allocator
+   {
+      typedef boost::container::small_vector<int, 0> cont;
+      if (boost::has_trivial_destructor_after_move<cont>::value) {
+         std::cerr << "has_trivial_destructor_after_move(default allocator) test failed" << std::endl;
+         return 1;
+      }
+   }
+   // std::allocator
+   {
+      typedef boost::container::small_vector<int, 0, std::allocator<int> > cont;
+      if (boost::has_trivial_destructor_after_move<cont>::value) {
+         std::cerr << "has_trivial_destructor_after_move(std::allocator) test failed" << std::endl;
+         return 1;
+      }
+   }
+
    return 0;
 }

--- a/test/stable_vector_test.cpp
+++ b/test/stable_vector_test.cpp
@@ -193,6 +193,34 @@ int main()
    }
 #endif
 
+   ////////////////////////////////////
+   //    has_trivial_destructor_after_move testing
+   ////////////////////////////////////
+   // default allocator
+   {
+      typedef boost::container::stable_vector<int> cont;
+      typedef cont::allocator_type allocator_type;
+      typedef boost::container::allocator_traits<allocator_type>::pointer pointer;
+      if (boost::has_trivial_destructor_after_move<cont>::value !=
+          boost::has_trivial_destructor_after_move<allocator_type>::value &&
+          boost::has_trivial_destructor_after_move<pointer>::value) {
+         std::cerr << "has_trivial_destructor_after_move(default allocator) test failed" << std::endl;
+         return 1;
+      }
+   }
+   // std::allocator
+   {
+      typedef boost::container::stable_vector<int, std::allocator<int> > cont;
+      typedef cont::allocator_type allocator_type;
+      typedef boost::container::allocator_traits<allocator_type>::pointer pointer;
+      if (boost::has_trivial_destructor_after_move<cont>::value !=
+          boost::has_trivial_destructor_after_move<allocator_type>::value &&
+          boost::has_trivial_destructor_after_move<pointer>::value) {
+         std::cerr << "has_trivial_destructor_after_move(std::allocator) test failed" << std::endl;
+         return 1;
+      }
+   }
+
    return 0;
 }
 

--- a/test/string_test.cpp
+++ b/test/string_test.cpp
@@ -562,6 +562,34 @@ int main()
          return 1;
    }
 
+   ////////////////////////////////////
+   //    has_trivial_destructor_after_move testing
+   ////////////////////////////////////
+   // default allocator
+   {
+      typedef boost::container::basic_string<char> cont;
+      typedef cont::allocator_type allocator_type;
+      typedef boost::container::allocator_traits<allocator_type>::pointer pointer;
+      if (boost::has_trivial_destructor_after_move<cont>::value !=
+          boost::has_trivial_destructor_after_move<allocator_type>::value &&
+          boost::has_trivial_destructor_after_move<pointer>::value) {
+         std::cerr << "has_trivial_destructor_after_move(default allocator) test failed" << std::endl;
+         return 1;
+      }
+   }
+   // std::allocator
+   {
+      typedef boost::container::basic_string<char, std::char_traits<char>, std::allocator<char> > cont;
+      typedef cont::allocator_type allocator_type;
+      typedef boost::container::allocator_traits<allocator_type>::pointer pointer;
+      if (boost::has_trivial_destructor_after_move<cont>::value !=
+          boost::has_trivial_destructor_after_move<allocator_type>::value &&
+          boost::has_trivial_destructor_after_move<pointer>::value) {
+         std::cerr << "has_trivial_destructor_after_move(std::allocator) test failed" << std::endl;
+         return 1;
+      }
+   }
+
    return boost::report_errors();
 }
 

--- a/test/tree_test.cpp
+++ b/test/tree_test.cpp
@@ -9,6 +9,10 @@
 //////////////////////////////////////////////////////////////////////////////
 #include <boost/container/detail/tree.hpp>
 #include <boost/container/adaptive_pool.hpp>
+#include <boost/container/new_allocator.hpp>
+#include <boost/move/traits.hpp>
+
+#include <iostream>
 
 #include "movable_int.hpp"
 #include "dummy_test_allocator.hpp"
@@ -79,5 +83,37 @@ template class tree
 
 int main ()
 {
+   ////////////////////////////////////
+   //    has_trivial_destructor_after_move testing
+   ////////////////////////////////////
+   // default
+   {
+      typedef boost::container::dtl::tree<int, void, std::less<int>, void, void> tree;
+      typedef tree::allocator_type allocator_type;
+      typedef boost::container::allocator_traits<allocator_type>::pointer pointer;
+      typedef tree::key_compare key_compare;
+      if (boost::has_trivial_destructor_after_move<tree>::value !=
+          boost::has_trivial_destructor_after_move<allocator_type>::value &&
+          boost::has_trivial_destructor_after_move<pointer>::value &&
+          boost::has_trivial_destructor_after_move<key_compare>::value) {
+         std::cerr << "has_trivial_destructor_after_move(default allocator) test failed" << std::endl;
+         return 1;
+      }
+   }
+   // std::allocator
+   {
+      typedef boost::container::dtl::tree<int, void, std::less<int>, std::allocator<int>, void> tree;
+      typedef tree::allocator_type allocator_type;
+      typedef boost::container::allocator_traits<allocator_type>::pointer pointer;
+      typedef tree::key_compare key_compare;
+      if (boost::has_trivial_destructor_after_move<tree>::value !=
+          boost::has_trivial_destructor_after_move<allocator_type>::value &&
+          boost::has_trivial_destructor_after_move<pointer>::value &&
+          boost::has_trivial_destructor_after_move<key_compare>::value) {
+         std::cerr << "has_trivial_destructor_after_move(std::allocator) test failed" << std::endl;
+         return 1;
+      }
+   }
+
    return 0;
 }

--- a/test/vector_test.cpp
+++ b/test/vector_test.cpp
@@ -332,5 +332,33 @@ int main()
       return 1;
    }
 
+   ////////////////////////////////////
+   //    has_trivial_destructor_after_move testing
+   ////////////////////////////////////
+   // default allocator
+   {
+      typedef boost::container::vector<int> cont;
+      typedef cont::allocator_type allocator_type;
+      typedef boost::container::allocator_traits<allocator_type>::pointer pointer;
+      if (boost::has_trivial_destructor_after_move<cont>::value !=
+          boost::has_trivial_destructor_after_move<allocator_type>::value &&
+          boost::has_trivial_destructor_after_move<pointer>::value) {
+         std::cerr << "has_trivial_destructor_after_move(default allocator) test failed" << std::endl;
+         return 1;
+      }
+   }
+   // std::allocator
+   {
+      typedef boost::container::vector<int, std::allocator<int> > cont;
+      typedef cont::allocator_type allocator_type;
+      typedef boost::container::allocator_traits<allocator_type>::pointer pointer;
+      if (boost::has_trivial_destructor_after_move<cont>::value !=
+          boost::has_trivial_destructor_after_move<allocator_type>::value &&
+          boost::has_trivial_destructor_after_move<pointer>::value) {
+         std::cerr << "has_trivial_destructor_after_move(std::allocator) test failed" << std::endl;
+         return 1;
+      }
+   }
+
    return 0;
 }


### PR DESCRIPTION
Most template type parameters 'Allocator' were modified their default type to void since 1.70.0.
These modifications cause has_trivial_destructor_after_move to compile error or yield wrong result.
So, fix them by changing specializations of has_trivial_destructor_after_move.