### PR TITLE
With heterogeneous lookup, `equal_range` can result in a range with length greater than 1.

### DIFF
--- a/include/boost/container/flat_map.hpp
+++ b/include/boost/container/flat_map.hpp
@@ -1465,7 +1465,7 @@ class flat_map
    //! <b>Complexity</b>: Logarithmic.
    template<class K>
    BOOST_CONTAINER_FORCEINLINE std::pair<iterator,iterator> equal_range(const K& x)
-      {  return dtl::force_copy<std::pair<iterator,iterator> >(m_flat_tree.lower_bound_range(x)); }
+      {  return dtl::force_copy<std::pair<iterator,iterator> >(m_flat_tree.equal_range(x)); }
 
    //! <b>Requires</b>: This overload is available only if
    //! key_compare::is_transparent exists.
@@ -1475,7 +1475,7 @@ class flat_map
    //! <b>Complexity</b>: Logarithmic.
    template<class K>
    BOOST_CONTAINER_FORCEINLINE std::pair<const_iterator, const_iterator> equal_range(const K& x) const
-      {  return dtl::force_copy<std::pair<const_iterator,const_iterator> >(m_flat_tree.lower_bound_range(x)); }
+      {  return dtl::force_copy<std::pair<const_iterator,const_iterator> >(m_flat_tree.equal_range(x)); }
 
    //! <b>Effects</b>: Extracts the internal sequence container.
    //!

--- a/include/boost/container/flat_set.hpp
+++ b/include/boost/container/flat_set.hpp
@@ -1031,7 +1031,7 @@ class flat_set
    //! <b>Complexity</b>: Logarithmic
    template<typename K>
    std::pair<iterator,iterator> equal_range(const K& x)
-   {  return this->tree_t::lower_bound_range(x);  }
+   {  return this->tree_t::equal_range(x);  }
 
    //! <b>Requires</b>: This overload is available only if
    //! key_compare::is_transparent exists.
@@ -1041,7 +1041,7 @@ class flat_set
    //! <b>Complexity</b>: Logarithmic
    template<typename K>
    std::pair<const_iterator,const_iterator> equal_range(const K& x) const
-   {  return this->tree_t::lower_bound_range(x);  }
+   {  return this->tree_t::equal_range(x);  }
 
    #if defined(BOOST_CONTAINER_DOXYGEN_INVOKED)
 

--- a/test/flat_map_test.cpp
+++ b/test/flat_map_test.cpp
@@ -581,7 +581,7 @@ struct with_lookup_by_first
 
 bool test_heterogeneous_lookup_by_partial_key()
 {
-   flat_map<std::pair<int, int>, with_lookup_by_first> const map1
+   flat_map<std::pair<int, int>,int, with_lookup_by_first> const map1
    {
       {{0, 1}, 3},
       {{0, 2}, 3},

--- a/test/flat_map_test.cpp
+++ b/test/flat_map_test.cpp
@@ -22,6 +22,7 @@
 #include "../../intrusive/test/iterator_test.hpp"
 
 #include <map>
+#include <utility>
 
 
 using namespace boost::container;
@@ -557,6 +558,37 @@ bool test_heterogeneous_lookups()
    return true;
 }
 
+// An ordered sequence of std:pair is also ordered by std::pair::first.
+struct with_lookup_by_first
+{
+   typedef void is_transparent;
+   inline bool operator()(std::pair<int, int> a, std::pair<int, int> b) const
+   {
+      return a < b;
+   }
+   inline bool operator()(std::pair<int, int> a, int first) const
+   {
+      return a.first < first;
+   }
+   inline bool operator()(int first, std::pair<int, int> b) const
+   {
+      return first < b.first;
+   }
+};
+
+bool test_heterogeneous_lookup_by_partial_key()
+{
+   flat_set<std::pair<int, int>, with_lookup_by_first> const set1
+   {
+      {{0, 1}, 3},
+      {{0, 2}, 3},
+   };
+
+   auto const first_0_range = uut.equal_range(0);
+
+   return 2 == first_0_range.second - first_0_range.first;
+}
+
 }}}   //namespace boost::container::test
 
 int main()
@@ -615,6 +647,9 @@ int main()
       return 1;
 
    if (!test_heterogeneous_lookups())
+      return 1;
+
+   if (!test_heterogeneous_lookup_by_partial_key())
       return 1;
 
    ////////////////////////////////////

--- a/test/flat_map_test.cpp
+++ b/test/flat_map_test.cpp
@@ -581,13 +581,13 @@ struct with_lookup_by_first
 
 bool test_heterogeneous_lookup_by_partial_key()
 {
-   flat_set<std::pair<int, int>, with_lookup_by_first> const set1
+   flat_map<std::pair<int, int>, with_lookup_by_first> const map1
    {
       {{0, 1}, 3},
       {{0, 2}, 3},
    };
 
-   auto const first_0_range = uut.equal_range(0);
+   auto const first_0_range = map1.equal_range(0);
 
    return 2 == first_0_range.second - first_0_range.first;
 }

--- a/test/flat_map_test.cpp
+++ b/test/flat_map_test.cpp
@@ -581,13 +581,13 @@ struct with_lookup_by_first
 
 bool test_heterogeneous_lookup_by_partial_key()
 {
-   flat_map<std::pair<int, int>,int, with_lookup_by_first> const map1
-   {
-      {{0, 1}, 3},
-      {{0, 2}, 3},
-   };
+   typedef flat_map<std::pair<int, int>,int, with_lookup_by_first> map_t;
 
-   auto const first_0_range = map1.equal_range(0);
+   map_t map1;
+   map1[std::pair<int, int>(0, 1)] = 3;
+   map1[std::pair<int, int>(0, 2)] = 3;
+
+   std::pair<map_t::iterator, map_t::iterator> const first_0_range = map1.equal_range(0);
 
    return 2 == first_0_range.second - first_0_range.first;
 }

--- a/test/flat_set_test.cpp
+++ b/test/flat_set_test.cpp
@@ -603,7 +603,7 @@ bool test_heterogeneous_lookup_by_partial_key()
       {0, 2},
    };
 
-   auto const first_0_range = uut.equal_range(0);
+   auto const first_0_range = set1.equal_range(0);
 
    return 2 == first_0_range.second - first_0_range.first;
 }

--- a/test/flat_set_test.cpp
+++ b/test/flat_set_test.cpp
@@ -11,6 +11,7 @@
 #include <boost/container/detail/config_begin.hpp>
 
 #include <set>
+#include <utility>
 
 #include <boost/container/flat_set.hpp>
 #include <boost/container/detail/container_or_allocator_rebind.hpp>
@@ -574,6 +575,37 @@ bool test_heterogeneous_lookups()
    return true;
 }
 
+// An ordered sequence of std:pair is also ordered by std::pair::first.
+struct with_lookup_by_first
+{
+   typedef void is_transparent;
+   inline bool operator()(std::pair<int, int> a, std::pair<int, int> b) const
+   {
+      return a < b;
+   }
+   inline bool operator()(std::pair<int, int> a, int first) const
+   {
+      return a.first < first;
+   }
+   inline bool operator()(int first, std::pair<int, int> b) const
+   {
+      return first < b.first;
+   }
+};
+
+bool test_heterogeneous_lookup_by_partial_key()
+{
+   flat_set<std::pair<int, int>, with_lookup_by_first> const set1
+   {
+      {0, 1},
+      {0, 2},
+   };
+
+   auto const first_0_range = uut.equal_range(0);
+
+   return 2 == first_0_range.second - first_0_range.first;
+}
+
 }}}
 
 template<class VoidAllocatorOrContainer>
@@ -712,6 +744,10 @@ int main()
       return 1;
 
    if(!test_heterogeneous_lookups()){
+      return 1;
+   }
+
+   if(!test_heterogeneous_lookup_by_partial_key()){
       return 1;
    }
 

--- a/test/flat_set_test.cpp
+++ b/test/flat_set_test.cpp
@@ -597,13 +597,13 @@ struct with_lookup_by_first
 
 bool test_heterogeneous_lookup_by_partial_key()
 {
-   flat_set<std::pair<int, int>, with_lookup_by_first> const set1
-   {
-      {0, 1},
-      {0, 2},
-   };
+   typedef flat_set<std::pair<int, int>, with_lookup_by_first> set_t;
 
-   auto const first_0_range = set1.equal_range(0);
+   set_t set1;
+   set1.insert(std::pair<int, int>(0, 1));
+   set1.insert(std::pair<int, int>(0, 2));
+
+   std::pair<set_t::iterator, set_t::iterator> const first_0_range = set1.equal_range(0);
 
    return 2 == first_0_range.second - first_0_range.first;
 }


### PR DESCRIPTION
Do we need tests?