### PR TITLE
Fix docs for static_vector::max_size() and capacity()

### DIFF
--- a/include/boost/container/static_vector.hpp
+++ b/include/boost/container/static_vector.hpp
@@ -1125,7 +1125,7 @@ public:
     //!
     //! @par Complexity
     //!   Constant O(1).
-    static size_type capacity() BOOST_NOEXCEPT_OR_NOTHROW;
+    size_type capacity() const BOOST_NOEXCEPT_OR_NOTHROW;
 
     //! @brief Returns container's capacity.
     //!
@@ -1136,7 +1136,7 @@ public:
     //!
     //! @par Complexity
     //!   Constant O(1).
-    static size_type max_size() BOOST_NOEXCEPT_OR_NOTHROW;
+    size_type max_size() const BOOST_NOEXCEPT_OR_NOTHROW;
 
     //! @brief Returns the number of stored elements.
     //!


### PR DESCRIPTION
The documentation for `static_vector::max_size()` and `static_vector::capacity()` list them as `static` member functions; however, they are actually implemented as non-static `const` member functions. This PR fixes this discrepancy by changing the documentation to match the implementation.

The alternative would be to change the implementations to be `static` (which they could be, since for `static_vector<T, N>`, both simply return `N`). However, this is difficult due to the way `static_vector` is implemented (it inherits these member functions from `vector`), and besides, there already exists `static_vector::static_capacity` to accomplish the same thing statically.