### PR TITLE
Missing BOOST_NORETURN for user defined functions

### DIFF
--- a/include/boost/container/throw_exception.hpp
+++ b/include/boost/container/throw_exception.hpp
@@ -37,15 +37,15 @@ namespace container {
 #if defined(BOOST_CONTAINER_USER_DEFINED_THROW_CALLBACKS)
    //The user must provide definitions for the following functions
 
-   void throw_bad_alloc();
+   BOOST_NORETURN void throw_bad_alloc();
 
-   void throw_out_of_range(const char* str);
+   BOOST_NORETURN void throw_out_of_range(const char* str);
 
-   void throw_length_error(const char* str);
+   BOOST_NORETURN void throw_length_error(const char* str);
 
-   void throw_logic_error(const char* str);
+   BOOST_NORETURN void throw_logic_error(const char* str);
 
-   void throw_runtime_error(const char* str);
+   BOOST_NORETURN void throw_runtime_error(const char* str);
 
 #elif defined(BOOST_NO_EXCEPTIONS)
 

--- a/test/throw_exception_test.cpp
+++ b/test/throw_exception_test.cpp
@@ -22,24 +22,50 @@ static bool length_error_called  = false;
 static bool logic_error_called   = false;
 static bool runtime_error_called = false;
 
+BOOST_NORETURN static void validate_and_never_return()
+{
+   BOOST_TEST(bad_alloc_called == true);
+   BOOST_TEST(out_of_range_called == true);
+   BOOST_TEST(length_error_called == true);
+   BOOST_TEST(logic_error_called == true);
+   BOOST_TEST(runtime_error_called == true);
+   std::exit(::boost::report_errors());
+}
+
 //User defined throw implementations
 namespace boost {
 namespace container {
 
-   void throw_bad_alloc()
-   {  bad_alloc_called = true;   }
+   BOOST_NORETURN void throw_bad_alloc()
+   {
+      bad_alloc_called = true;
+      throw_out_of_range("dummy");
+   }
 
-   void throw_out_of_range(const char* str)
-   {  (void)str; out_of_range_called = true;   }
+   BOOST_NORETURN void throw_out_of_range(const char* str)
+   {
+      out_of_range_called = true;
+      throw_length_error(str);
+   }
 
-   void throw_length_error(const char* str)
-   {  (void)str; length_error_called = true;   }
+   BOOST_NORETURN void throw_length_error(const char* str)
+   {
+      length_error_called = true;
+      throw_logic_error(str);
+   }
 
-   void throw_logic_error(const char* str)
-   {  (void)str; logic_error_called = true; }
+   BOOST_NORETURN void throw_logic_error(const char* str)
+   {
+      logic_error_called = true;
+      throw_runtime_error(str);
+   }
 
-   void throw_runtime_error(const char* str)
-   {  (void)str; runtime_error_called = true;  }
+   BOOST_NORETURN void throw_runtime_error(const char* str)
+   {
+      (void)str;
+      runtime_error_called = true;
+      validate_and_never_return();
+   }
 
 }} //boost::container
 
@@ -47,16 +73,8 @@ int main()
 {
    //Check user-defined throw callbacks are called
    throw_bad_alloc();
-   BOOST_TEST(bad_alloc_called == true);
-   throw_out_of_range("dummy");
-   BOOST_TEST(out_of_range_called == true);
-   throw_length_error("dummy");
-   BOOST_TEST(length_error_called == true);
-   throw_logic_error("dummy");
-   BOOST_TEST(logic_error_called == true);
-   throw_runtime_error("dummy");
-   BOOST_TEST(runtime_error_called == true);
-   return ::boost::report_errors();
+   //Never reached
+   std::abort();
 }
 
 #include <boost/container/detail/config_end.hpp>


### PR DESCRIPTION
BOOST_NORETURN is missing for the interface of the throwning methods when BOOST_CONTAINER_USER_DEFINED_THROW_CALLBACKS is defined. Without them you can get a `'noreturn' function does return` warning from g++ at `boost/container/static_vector.hpp:46:4`.