### PR TITLE
Use BOOST_OVERRIDE

### DIFF
--- a/include/boost/container/pmr/monotonic_buffer_resource.hpp
+++ b/include/boost/container/pmr/monotonic_buffer_resource.hpp
@@ -109,7 +109,7 @@ class BOOST_CONTAINER_DECL monotonic_buffer_resource
 
    //! <b>Effects</b>: Calls
    //!   `this->release()`.
-   virtual ~monotonic_buffer_resource();
+   ~monotonic_buffer_resource() BOOST_OVERRIDE;
 
    //! <b>Effects</b>: `upstream_resource()->deallocate()` as necessary to release all allocated memory.
    //!   [Note: memory is released back to `upstream_resource()` even if some blocks that were allocated
@@ -160,18 +160,18 @@ class BOOST_CONTAINER_DECL monotonic_buffer_resource
    //!   then allocate the return block from the newly-allocated internal `current_buffer`.
    //!
    //! <b>Throws</b>: Nothing unless `upstream_resource()->allocate()` throws.
-   virtual void* do_allocate(std::size_t bytes, std::size_t alignment);
+   void* do_allocate(std::size_t bytes, std::size_t alignment) BOOST_OVERRIDE;
 
    //! <b>Effects</b>: None
    //!
    //! <b>Throws</b>: Nothing
    //!
    //! <b>Remarks</b>: Memory used by this resource increases monotonically until its destruction.
-   virtual void do_deallocate(void* p, std::size_t bytes, std::size_t alignment) BOOST_NOEXCEPT;
+   void do_deallocate(void* p, std::size_t bytes, std::size_t alignment) BOOST_NOEXCEPT BOOST_OVERRIDE;
 
    //! <b>Returns</b>:
    //!   `this == dynamic_cast<const monotonic_buffer_resource*>(&other)`.
-   virtual bool do_is_equal(const memory_resource& other) const BOOST_NOEXCEPT;
+   bool do_is_equal(const memory_resource& other) const BOOST_NOEXCEPT BOOST_OVERRIDE;
 };
 
 }  //namespace pmr {

--- a/include/boost/container/pmr/synchronized_pool_resource.hpp
+++ b/include/boost/container/pmr/synchronized_pool_resource.hpp
@@ -89,7 +89,7 @@ class BOOST_CONTAINER_DECL synchronized_pool_resource
    #endif
 
    //! @copydoc ::boost::container::pmr::unsynchronized_pool_resource::~unsynchronized_pool_resource()
-   virtual ~synchronized_pool_resource();
+   ~synchronized_pool_resource() BOOST_OVERRIDE;
 
    //! @copydoc ::boost::container::pmr::unsynchronized_pool_resource::release()
    void release();
@@ -103,13 +103,13 @@ class BOOST_CONTAINER_DECL synchronized_pool_resource
    protected:
 
    //! @copydoc ::boost::container::pmr::unsynchronized_pool_resource::do_allocate()
-   virtual void* do_allocate(std::size_t bytes, std::size_t alignment);
+   void* do_allocate(std::size_t bytes, std::size_t alignment) BOOST_OVERRIDE;
 
    //! @copydoc ::boost::container::pmr::unsynchronized_pool_resource::do_deallocate(void*,std::size_t,std::size_t)
-   virtual void do_deallocate(void* p, std::size_t bytes, std::size_t alignment);
+   void do_deallocate(void* p, std::size_t bytes, std::size_t alignment) BOOST_OVERRIDE;
 
    //! @copydoc ::boost::container::pmr::unsynchronized_pool_resource::do_is_equal(const memory_resource&)const
-   virtual bool do_is_equal(const memory_resource& other) const BOOST_NOEXCEPT;
+   bool do_is_equal(const memory_resource& other) const BOOST_NOEXCEPT BOOST_OVERRIDE;
 
    //Non-standard observers
    public:

--- a/include/boost/container/pmr/unsynchronized_pool_resource.hpp
+++ b/include/boost/container/pmr/unsynchronized_pool_resource.hpp
@@ -103,7 +103,7 @@ class BOOST_CONTAINER_DECL unsynchronized_pool_resource
 
    //! <b>Effects</b>: Calls
    //!   `this->release()`.
-   virtual ~unsynchronized_pool_resource();
+   ~unsynchronized_pool_resource() BOOST_OVERRIDE;
 
    //! <b>Effects</b>: Calls Calls `upstream_resource()->deallocate()` as necessary
    //!   to release all allocated memory. [ Note: memory is released back to
@@ -134,18 +134,18 @@ class BOOST_CONTAINER_DECL unsynchronized_pool_resource
    //!   using `upstream_resource()->allocate()`.
    //!
    //! <b>Throws</b>: Nothing unless `upstream_resource()->allocate()` throws.
-   virtual void* do_allocate(std::size_t bytes, std::size_t alignment);
+   void* do_allocate(std::size_t bytes, std::size_t alignment) BOOST_OVERRIDE;
 
    //! <b>Effects</b>: Return the memory at p to the pool. It is unspecified if or under
    //!   what circumstances this operation will result in a call to
    //!   `upstream_resource()->deallocate()`.
    //!
    //! <b>Throws</b>: Nothing.
-   virtual void do_deallocate(void* p, std::size_t bytes, std::size_t alignment);
+   void do_deallocate(void* p, std::size_t bytes, std::size_t alignment) BOOST_OVERRIDE;
 
    //! <b>Returns</b>:
    //!   `this == dynamic_cast<const unsynchronized_pool_resource*>(&other)`.
-   virtual bool do_is_equal(const memory_resource& other) const BOOST_NOEXCEPT;
+   bool do_is_equal(const memory_resource& other) const BOOST_NOEXCEPT BOOST_OVERRIDE;
 
    //Non-standard observers
    public:

--- a/src/global_resource.cpp
+++ b/src/global_resource.cpp
@@ -13,7 +13,7 @@
 #include <boost/container/pmr/global_resource.hpp>
 #include <boost/core/no_exceptions_support.hpp>
 #include <boost/container/throw_exception.hpp>
-#include <boost/container/detail/dlmalloc.hpp>  //For global lock
+#include <boost/container/detail/dlmalloc.hpp>  // For global lock
 
 #include <cstddef>
 #include <new>
@@ -27,16 +27,16 @@ class new_delete_resource_imp
 {
    public:
 
-   virtual ~new_delete_resource_imp()
+   ~new_delete_resource_imp() BOOST_OVERRIDE
    {}
 
-   virtual void* do_allocate(std::size_t bytes, std::size_t alignment)
+   void* do_allocate(std::size_t bytes, std::size_t alignment) BOOST_OVERRIDE
    {  (void)bytes; (void)alignment; return new char[bytes];  }
 
-   virtual void do_deallocate(void* p, std::size_t bytes, std::size_t alignment)
+   void do_deallocate(void* p, std::size_t bytes, std::size_t alignment) BOOST_OVERRIDE
    {  (void)bytes; (void)alignment; delete[]((char*)p);  }
 
-   virtual bool do_is_equal(const memory_resource& other) const BOOST_NOEXCEPT
+   bool do_is_equal(const memory_resource& other) const BOOST_NOEXCEPT BOOST_OVERRIDE
    {  return &other == this;   }
 } new_delete_resource_instance;
 
@@ -45,20 +45,20 @@ struct null_memory_resource_imp
 {
    public:
 
-   virtual ~null_memory_resource_imp()
+   ~null_memory_resource_imp() BOOST_OVERRIDE
    {}
 
-   virtual void* do_allocate(std::size_t bytes, std::size_t alignment)
+   void* do_allocate(std::size_t bytes, std::size_t alignment) BOOST_OVERRIDE
    {
       (void)bytes; (void)alignment;
       throw_bad_alloc();
       return 0;
    }
 
-   virtual void do_deallocate(void* p, std::size_t bytes, std::size_t alignment)
+   void do_deallocate(void* p, std::size_t bytes, std::size_t alignment) BOOST_OVERRIDE
    {  (void)p;  (void)bytes; (void)alignment;  }
 
-   virtual bool do_is_equal(const memory_resource& other) const BOOST_NOEXCEPT
+   bool do_is_equal(const memory_resource& other) const BOOST_NOEXCEPT BOOST_OVERRIDE
    {  return &other == this;   }
 } null_memory_resource_instance;
 


### PR DESCRIPTION
Use BOOST_OVERRIDE to fix GCC -Wsuggest-override and Clang-tidy modernize-use-override warnings.