### PR TITLE
InitializeCriticalSectionEx returns "BOOL" (int)

### DIFF
--- a/include/boost/container/detail/thread_mutex.hpp
+++ b/include/boost/container/detail/thread_mutex.hpp
@@ -104,7 +104,7 @@ namespace container {
 namespace dtl {
 
 #ifdef BOOST_PLAT_WINDOWS_UWP
-extern "C" __declspec(dllimport) void __stdcall InitializeCriticalSectionEx(::_RTL_CRITICAL_SECTION *, unsigned long, unsigned long);
+extern "C" __declspec(dllimport) int __stdcall an(::_RTL_CRITICAL_SECTION *, unsigned long, unsigned long);
 #else
 extern "C" __declspec(dllimport) void __stdcall InitializeCriticalSection(::_RTL_CRITICAL_SECTION *);
 #endif


### PR DESCRIPTION
Retcode of InitializeCriticalSectionEx was not correct:
https://docs.microsoft.com/en-us/windows/win32/api/synchapi/nf-synchapi-initializecriticalsectionex