### PR TITLE
Add missing include

### DIFF
--- a/include/boost/container/detail/compare_functors.hpp
+++ b/include/boost/container/detail/compare_functors.hpp
@@ -20,6 +20,7 @@
 #endif
 
 #include <boost/intrusive/detail/ebo_functor_holder.hpp>
+#include <boost/container/detail/workaround.hpp>
 
 namespace boost {
 namespace container {


### PR DESCRIPTION
This patch makes the header able to be built standalone, making possible C++ clang modules builds.