### PR TITLE
Remove BOOST_CONTAINER_DECL from memory_resource

### DIFF
--- a/include/boost/container/pmr/memory_resource.hpp
+++ b/include/boost/container/pmr/memory_resource.hpp
@@ -27,7 +27,7 @@ namespace pmr {
 
 //! The memory_resource class is an abstract interface to an
 //! unbounded set of classes encapsulating memory resources.
-class BOOST_CONTAINER_DECL memory_resource
+class memory_resource
 {
    public:
    // For exposition only


### PR DESCRIPTION
Hopefully fixes #165.

Since all member functions of `memory_resource` are either inline or pure, and since the class itself is abstract, there should be no need to dllexport it.

Tested locally on `toolset=msvc-10.0,msvc-11.0,msvc-12.0,msvc-14.0,msvc-14.1,msvc-14.2,clang-win,gcc`.