### PR TITLE
Add conditional noexcept forwarding from free to member swap functions.

### DIFF
--- a/include/boost/container/deque.hpp
+++ b/include/boost/container/deque.hpp
@@ -1910,6 +1910,7 @@ class deque : protected deque_base<typename real_allocator<T, Allocator>::type, 
    //!
    //! <b>Complexity</b>: Constant.
    BOOST_CONTAINER_FORCEINLINE friend void swap(deque& x, deque& y)
+       BOOST_NOEXCEPT_IF(BOOST_NOEXCEPT(x.swap(y)))
    {  x.swap(y);  }
 
    #ifndef BOOST_CONTAINER_DOXYGEN_INVOKED

--- a/include/boost/container/detail/flat_tree.hpp
+++ b/include/boost/container/detail/flat_tree.hpp
@@ -1448,6 +1448,7 @@ class flat_tree
       {  return !(x < y);  }
 
    BOOST_CONTAINER_FORCEINLINE friend void swap(flat_tree& x, flat_tree& y)
+          BOOST_NOEXCEPT_IF(BOOST_NOEXCEPT(x.swap(y)))
       {  x.swap(y);  }
 
    private:

--- a/include/boost/container/devector.hpp
+++ b/include/boost/container/devector.hpp
@@ -2000,6 +2000,8 @@ class devector
    {  return !(x < y);  }
 
    BOOST_CONTAINER_FORCEINLINE friend void swap(devector& x, devector& y)
+      BOOST_NOEXCEPT_IF( allocator_traits_type::propagate_on_container_swap::value
+                        || allocator_traits_type::is_always_equal::value)
    {  x.swap(y);  }
 
    private:

--- a/include/boost/container/flat_map.hpp
+++ b/include/boost/container/flat_map.hpp
@@ -1602,6 +1602,7 @@ class flat_map
    //!
    //! <b>Complexity</b>: Constant.
    BOOST_CONTAINER_FORCEINLINE friend void swap(flat_map& x, flat_map& y)
+       BOOST_NOEXCEPT_IF(BOOST_NOEXCEPT(x.swap(y)))
    {  x.swap(y);  }
 
    #ifndef BOOST_CONTAINER_DOXYGEN_INVOKED
@@ -2959,6 +2960,7 @@ class flat_multimap
    //!
    //! <b>Complexity</b>: Constant.
    BOOST_CONTAINER_FORCEINLINE friend void swap(flat_multimap& x, flat_multimap& y)
+       BOOST_NOEXCEPT_IF(BOOST_NOEXCEPT(x.swap(y)))
    {  x.swap(y);  }
 };
 

--- a/include/boost/container/flat_set.hpp
+++ b/include/boost/container/flat_set.hpp
@@ -1084,7 +1084,9 @@ class flat_set
    //! <b>Effects</b>: x.swap(y)
    //!
    //! <b>Complexity</b>: Constant.
-   friend void swap(flat_set& x, flat_set& y);
+   friend void swap(flat_set& x, flat_set& y)
+      BOOST_NOEXCEPT_IF(  allocator_traits_type::is_always_equal::value
+                                 && boost::container::dtl::is_nothrow_swappable<Compare>::value );
 
    //! <b>Effects</b>: Extracts the internal sequence container.
    //!
@@ -1817,7 +1819,9 @@ class flat_multiset
    //! <b>Effects</b>: x.swap(y)
    //!
    //! <b>Complexity</b>: Constant.
-   friend void swap(flat_multiset& x, flat_multiset& y);
+   friend void swap(flat_multiset& x, flat_multiset& y)
+      BOOST_NOEXCEPT_IF(  allocator_traits_type::is_always_equal::value
+                                 && boost::container::dtl::is_nothrow_swappable<Compare>::value );
 
    //! <b>Effects</b>: Extracts the internal sequence container.
    //!

--- a/include/boost/container/list.hpp
+++ b/include/boost/container/list.hpp
@@ -1439,6 +1439,7 @@ class list
    //!
    //! <b>Complexity</b>: Constant.
    BOOST_CONTAINER_FORCEINLINE friend void swap(list& x, list& y)
+       BOOST_NOEXCEPT_IF(BOOST_NOEXCEPT(x.swap(y)))
    {  x.swap(y);  }
 
    #ifndef BOOST_CONTAINER_DOXYGEN_INVOKED

--- a/include/boost/container/map.hpp
+++ b/include/boost/container/map.hpp
@@ -1062,7 +1062,7 @@ class map
    //! <b>Complexity</b>: Constant.
    void swap(map& x)
       BOOST_NOEXCEPT_IF(  allocator_traits_type::is_always_equal::value
-                                 && boost::container::dtl::is_nothrow_swappable<Compare>::value )
+                                 && boost::container::dtl::is_nothrow_swappable<Compare>::value );
 
    //! <b>Effects</b>: erase(begin(),end()).
    //!
@@ -1283,7 +1283,9 @@ class map
    //! <b>Effects</b>: x.swap(y)
    //!
    //! <b>Complexity</b>: Constant.
-   friend void swap(map& x, map& y);
+   friend void swap(map& x, map& y)
+      BOOST_NOEXCEPT_IF(  allocator_traits_type::is_always_equal::value
+                                 && boost::container::dtl::is_nothrow_swappable<Compare>::value );
 
    #endif   //#if defined(BOOST_CONTAINER_DOXYGEN_INVOKED)
 
@@ -2218,7 +2220,9 @@ class multimap
    //! <b>Effects</b>: x.swap(y)
    //!
    //! <b>Complexity</b>: Constant.
-   friend void swap(multimap& x, multimap& y);
+   friend void swap(multimap& x, multimap& y)
+      BOOST_NOEXCEPT_IF(  allocator_traits_type::is_always_equal::value
+                                 && boost::container::dtl::is_nothrow_swappable<Compare>::value );
 
    #endif   //#if defined(BOOST_CONTAINER_DOXYGEN_INVOKED)
 };

--- a/include/boost/container/set.hpp
+++ b/include/boost/container/set.hpp
@@ -945,7 +945,9 @@ class set
    //! <b>Effects</b>: x.swap(y)
    //!
    //! <b>Complexity</b>: Constant.
-   friend void swap(set& x, set& y);
+   friend void swap(set& x, set& y)
+      BOOST_NOEXCEPT_IF(  allocator_traits_type::is_always_equal::value
+                                 && boost::container::dtl::is_nothrow_swappable<Compare>::value );
 
    #endif   //#if defined(BOOST_CONTAINER_DOXYGEN_INVOKED)
 
@@ -1608,7 +1610,9 @@ class multiset
    //! <b>Effects</b>: x.swap(y)
    //!
    //! <b>Complexity</b>: Constant.
-   friend void swap(multiset& x, multiset& y);
+   friend void swap(multiset& x, multiset& y)
+      BOOST_NOEXCEPT_IF(  allocator_traits_type::is_always_equal::value
+                                 && boost::container::dtl::is_nothrow_swappable<Compare>::value );
 
    #endif   //#if defined(BOOST_CONTAINER_DOXYGEN_INVOKED)
 

--- a/include/boost/container/slist.hpp
+++ b/include/boost/container/slist.hpp
@@ -1629,6 +1629,7 @@ class slist
    //!
    //! <b>Complexity</b>: Constant.
    friend void swap(slist& x, slist& y)
+       BOOST_NOEXCEPT_IF(BOOST_NOEXCEPT(x.swap(y)))
    {  x.swap(y);  }
 
    #ifndef BOOST_CONTAINER_DOXYGEN_INVOKED

--- a/include/boost/container/stable_vector.hpp
+++ b/include/boost/container/stable_vector.hpp
@@ -1840,6 +1840,7 @@ class stable_vector
    //!
    //! <b>Complexity</b>: Constant.
    BOOST_CONTAINER_FORCEINLINE friend void swap(stable_vector& x, stable_vector& y)
+       BOOST_NOEXCEPT_IF(BOOST_NOEXCEPT(x.swap(y)))
    {  x.swap(y);  }
 
    #ifndef BOOST_CONTAINER_DOXYGEN_INVOKED

--- a/include/boost/container/static_vector.hpp
+++ b/include/boost/container/static_vector.hpp
@@ -1169,6 +1169,7 @@ public:
 #else
 
    BOOST_CONTAINER_FORCEINLINE friend void swap(static_vector &x, static_vector &y)
+       BOOST_NOEXCEPT_IF(BOOST_NOEXCEPT(x.swap(y)))
    {
       x.swap(y);
    }
@@ -1275,13 +1276,15 @@ bool operator>= (static_vector<V, C1, O1> const& x, static_vector<V, C2, O2> con
 //! @par Complexity
 //!   Linear O(N).
 template<typename V, std::size_t C1, std::size_t C2, class O1, class O2>
-inline void swap(static_vector<V, C1, O1> & x, static_vector<V, C2, O2> & y);
+inline void swap(static_vector<V, C1, O1> & x, static_vector<V, C2, O2> & y)
+    BOOST_NOEXCEPT_IF(BOOST_NOEXCEPT(x.swap(y)));
 
 #else
 
 template<typename V, std::size_t C1, std::size_t C2, class O1, class O2>
 inline void swap(static_vector<V, C1, O1> & x, static_vector<V, C2, O2> & y
       , typename dtl::enable_if_c< C1 != C2>::type * = 0)
+    BOOST_NOEXCEPT_IF(BOOST_NOEXCEPT(x.swap(y)))
 {
    x.swap(y);
 }

--- a/include/boost/container/string.hpp
+++ b/include/boost/container/string.hpp
@@ -3399,6 +3399,7 @@ operator>=( const basic_string<CharT,Traits,Allocator>& x, BasicStringView<CharT
 // Swap.
 template <class CharT, class Traits, class Allocator>
 inline void swap(basic_string<CharT,Traits,Allocator>& x, basic_string<CharT,Traits,Allocator>& y)
+    BOOST_NOEXCEPT_IF(BOOST_NOEXCEPT(x.swap(y)))
 {  x.swap(y);  }
 
 #ifndef BOOST_CONTAINER_DOXYGEN_INVOKED

--- a/include/boost/container/vector.hpp
+++ b/include/boost/container/vector.hpp
@@ -2197,6 +2197,7 @@ private:
    //!
    //! <b>Complexity</b>: Constant.
    BOOST_CONTAINER_FORCEINLINE friend void swap(vector& x, vector& y)
+       BOOST_NOEXCEPT_IF(BOOST_NOEXCEPT(x.swap(y)))
    {  x.swap(y);  }
 
    #ifndef BOOST_CONTAINER_DOXYGEN_INVOKED


### PR DESCRIPTION
This allows `std::is_nothrow_swappable{,_with}` to work properly.
This only touches user-facing classes, with the following exceptions:
- `map`,`set`: only doc changes (with a drive-by missing semicolon fix), `detail::tree` which they derive from already forwards `noexcept` for `swap`.
- `flat_set`: only doc changes for `flat_set` and a change for `detail::flat_tree`, which it derives from to get `swap`.
- `static_vector`: while this adds the forwarding, member `static_vector::swap` is currently never `noexcept`, although it could be for noexcept-swappable and noexcept-move-constructible elements.
- `small_vector`: there is no free swap, and member swap is never `noexcept`, although it could be for noexcept-swappable and noexcept-move-constructible elements. Swapping `small_vector`s of exact same type goes through `std::swap`, which seems to get `noexcept` right, and `small_vector`s of different sizes use `swap` for `boost::container::vector`, which fails to detect when such swap could be `noexcept`. This patch doesn't touch `small_vector`.
- `scoped_allocator`: neither member nor free `swap` are `noexcept`, although they should be, and all other constructions/assignments/comparisons too, as they only forward these operations to underlying allocators, which are required to not throw exceptions for them. Only `static_vector`'s `static_storage_allocator` might throw for these and it shouldn't appear in `scoped_allocator`. Unsure of the scope of changes needed or whether it is even worth it, this patch doesn't touch `scoped_allocator`.

I am unsure on the last three points, feel free to correct and cherry-pick as needed.