### PR TITLE
Fixes #195: Only allowing typedef iterator_concept in C++20

### DIFF
--- a/include/boost/container/vector.hpp
+++ b/include/boost/container/vector.hpp
@@ -65,6 +65,7 @@
 #include <boost/core/no_exceptions_support.hpp>
 #include <boost/assert.hpp>
 #include <boost/cstdint.hpp>
+#include <iterator>
 
 //std
 #if !defined(BOOST_NO_CXX11_HDR_INITIALIZER_LIST)
@@ -82,7 +83,9 @@ class vec_iterator
 {
    public:
    typedef std::random_access_iterator_tag                                          iterator_category;
+   #ifdef __cpp_lib_ranges
    typedef std::contiguous_iterator_tag                                             iterator_concept;
+   #endif
    typedef typename boost::intrusive::pointer_traits<Pointer>::element_type         value_type;
 
    //Defining element_type to make libstdc++'s std::pointer_traits well-formed leads to ambiguity

--- a/test/vector_test.cpp
+++ b/test/vector_test.cpp
@@ -19,6 +19,7 @@
 
 #include <boost/container/vector.hpp>
 #include <boost/container/allocator.hpp>
+#include <boost/type_traits/is_detected.hpp>
 
 #include <boost/move/utility_core.hpp>
 #include "check_equal_containers.hpp"
@@ -32,6 +33,18 @@
 #include "../../intrusive/test/iterator_test.hpp"
 
 using namespace boost::container;
+
+template<class T>
+using type_it_concept = typename T::iterator_concept;
+
+int test_iterator_concept_detected()
+{
+   return
+   #ifdef __cpp_lib_ranges
+      !
+   #endif
+   boost::is_detected_v<type_it_concept, vec_iterator<char *, true>>;
+}
 
 int test_expand_bwd()
 {
@@ -271,6 +284,9 @@ int main()
    }
 
    if (test_smart_ref_type())
+      return 1;
+
+   if (test_iterator_concept_detected())
       return 1;
 
    ////////////////////////////////////


### PR DESCRIPTION
Fixes https://github.com/boostorg/container/issues/195.

This follows my previous PR (https://github.com/boostorg/container/pull/196)  that I inadvertently closed with git.

