### PR TITLE
Document small_vector allocation strategy

### DIFF
--- a/include/boost/container/small_vector.hpp
+++ b/include/boost/container/small_vector.hpp
@@ -545,7 +545,7 @@ struct small_vector_storage_definer
 //! \tparam N The number of preallocated elements stored inside small_vector. It shall be less than Allocator::max_size();
 //! \tparam Allocator The allocator used for memory management when the number of elements exceeds N. Use void
 //!   for the default allocator
-//! |tparam Options A type produced from \c boost::container::small_vector_options.
+//! \tparam Options A type produced from \c boost::container::small_vector_options.
 template <class T, std::size_t N, class Allocator BOOST_CONTAINER_DOCONLY(= void), class Options BOOST_CONTAINER_DOCONLY(= void) >
 class small_vector : public small_vector_base<T, Allocator, Options>
    #ifndef BOOST_CONTAINER_DOXYGEN_INVOKED

--- a/include/boost/container/small_vector.hpp
+++ b/include/boost/container/small_vector.hpp
@@ -541,6 +541,9 @@ struct small_vector_storage_definer
 //!
 //! All `boost::container::vector` member functions are inherited. See `vector` documentation for details.
 //!
+//! Any change to the capacity of the vector, including decreasing its size such as with the shrink_to_fit method, will
+//! cause the vector to permanently switch to dynamically allocated storage.
+//!
 //! \tparam T The type of object that is stored in the small_vector
 //! \tparam N The number of preallocated elements stored inside small_vector. It shall be less than Allocator::max_size();
 //! \tparam Allocator The allocator used for memory management when the number of elements exceeds N. Use void


### PR DESCRIPTION
Since the purpose of this class is to optimize by using static storage, it is important to know what determines whether static or dynamic storage is used.

It looks like there is a doc/container.qbk file that should be updated for this change, but it looks autogenerated and I don't know how to regenerate it.