### PR TITLE
fix cmake files to enable standalone build and test

### DIFF
--- a/.cmake-format.yaml
+++ b/.cmake-format.yaml
@@ -1,0 +1,47 @@
+parse:
+  additional_commands:
+    _add_boost_lib:
+      # flags:
+      kwargs:
+        NAME: '1'
+        CXXFLAGS_PRIVATE: '*'
+        DEFINE: '*'
+        DEFINE_PRIVATE: '*'
+        INCLUDE_PRIVATE: '*'
+        LINK: '*'
+        SOURCES: '*'
+    _add_boost_test:
+      # flags:
+      kwargs:
+        NAME: '1'
+        RUN: '1'
+        DEFINE: '*'
+        LINK: '*'
+        TESTS: '*'
+    boost_test:
+      # flags:
+      kwargs:
+        NAME: '1'
+        PREFIX: '1'
+        TYPE: '1'
+        ARGUMENTS: '*'
+        LIBRARIES: '*'
+        SOURCES: '*'
+
+format:
+  dangle_parens: true
+  line_ending: unix
+  line_width: 123
+  max_lines_hwrap: 3
+  max_pargs_hwrap: 4
+  max_rows_cmdline: 8
+  max_subgroups_hwrap: 4
+  min_prefix_chars: 8
+  separate_ctrl_name_with_space: false
+  separate_fn_name_with_space: false
+  tab_size: 2
+
+markup:
+  bullet_char: "*"
+  enum_char: .
+  enable_markup: false

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,8 @@ cmake_minimum_required(VERSION 3.16...3.23)
 
 project(boost_container VERSION "${BOOST_SUPERPROJECT_VERSION}" LANGUAGES C CXX)
 
-add_library(boost_container
+add_library(
+  boost_container
   src/alloc_lib.c
   src/dlmalloc.cpp
   src/global_resource.cpp
@@ -16,22 +17,24 @@ add_library(boost_container
   src/unsynchronized_pool_resource.cpp
 )
 
-add_library(Boost::container ALIAS boost_container)
+if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/boost-cmake/CMakeLists.txt")
+  add_subdirectory(boost-cmake)
+
+  include(boost-cmake/cmake/Modules/ccache.cmake)
+else()
+  add_library(Boost::container ALIAS boost_container)
+
+  find_package(Boost 1.78)
+endif()
 
 target_include_directories(boost_container PUBLIC include)
 target_compile_features(boost_container PUBLIC cxx_std_20)
 
-find_package(Boost 1.78)
+target_link_libraries(boost_container PUBLIC Boost::headers)
 
-target_link_libraries(boost_container
-  PUBLIC
-    Boost::headers
-)
-
-target_compile_definitions(boost_container
-  PUBLIC BOOST_CONTAINER_NO_LIB
-  # Source files already define BOOST_CONTAINER_SOURCE
-  # PRIVATE BOOST_CONTAINER_SOURCE
+target_compile_definitions(
+  boost_container PUBLIC BOOST_CONTAINER_NO_LIB # Source files already define BOOST_CONTAINER_SOURCE
+                                                # PRIVATE BOOST_CONTAINER_SOURCE
 )
 
 if(BUILD_SHARED_LIBS)
@@ -40,10 +43,9 @@ else()
   target_compile_definitions(boost_container PUBLIC BOOST_CONTAINER_STATIC_LINK)
 endif()
 
+option(BUILD_TESTING "" ${PROJECT_IS_TOP_LEVEL})
 if(BUILD_TESTING AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/test/CMakeLists.txt")
-
   enable_testing()
 
   add_subdirectory(test)
-
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 # Distributed under the Boost Software License, Version 1.0.
 # https://www.boost.org/LICENSE_1_0.txt
 
-cmake_minimum_required(VERSION 3.5...3.16)
+cmake_minimum_required(VERSION 3.16...3.23)
 
 project(boost_container VERSION "${BOOST_SUPERPROJECT_VERSION}" LANGUAGES C CXX)
 
@@ -19,17 +19,13 @@ add_library(boost_container
 add_library(Boost::container ALIAS boost_container)
 
 target_include_directories(boost_container PUBLIC include)
+target_compile_features(boost_container PUBLIC cxx_std_20)
+
+find_package(Boost 1.78)
 
 target_link_libraries(boost_container
   PUBLIC
-    Boost::assert
-    Boost::config
-    Boost::core
-    Boost::intrusive
-    Boost::move
-    Boost::static_assert
-    Boost::type_traits
-    Boost::winapi
+    Boost::headers
 )
 
 target_compile_definitions(boost_container
@@ -45,6 +41,8 @@ else()
 endif()
 
 if(BUILD_TESTING AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/test/CMakeLists.txt")
+
+  enable_testing()
 
   add_subdirectory(test)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,12 +2,11 @@
 # Distributed under the Boost Software License, Version 1.0.
 # https://www.boost.org/LICENSE_1_0.txt
 
-cmake_minimum_required(VERSION 3.16...3.23)
+cmake_minimum_required(VERSION 3.5...3.16)
 
 project(boost_container VERSION "${BOOST_SUPERPROJECT_VERSION}" LANGUAGES C CXX)
 
-add_library(
-  boost_container
+add_library(boost_container
   src/alloc_lib.c
   src/dlmalloc.cpp
   src/global_resource.cpp
@@ -17,24 +16,26 @@ add_library(
   src/unsynchronized_pool_resource.cpp
 )
 
-if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/boost-cmake/CMakeLists.txt")
-  add_subdirectory(boost-cmake)
-
-  include(boost-cmake/cmake/Modules/ccache.cmake)
-else()
-  add_library(Boost::container ALIAS boost_container)
-
-  find_package(Boost 1.78)
-endif()
+add_library(Boost::container ALIAS boost_container)
 
 target_include_directories(boost_container PUBLIC include)
-target_compile_features(boost_container PUBLIC cxx_std_20)
 
-target_link_libraries(boost_container PUBLIC Boost::headers)
+target_link_libraries(boost_container
+  PUBLIC
+    Boost::assert
+    Boost::config
+    Boost::core
+    Boost::intrusive
+    Boost::move
+    Boost::static_assert
+    Boost::type_traits
+    Boost::winapi
+)
 
-target_compile_definitions(
-  boost_container PUBLIC BOOST_CONTAINER_NO_LIB # Source files already define BOOST_CONTAINER_SOURCE
-                                                # PRIVATE BOOST_CONTAINER_SOURCE
+target_compile_definitions(boost_container
+  PUBLIC BOOST_CONTAINER_NO_LIB
+  # Source files already define BOOST_CONTAINER_SOURCE
+  # PRIVATE BOOST_CONTAINER_SOURCE
 )
 
 if(BUILD_SHARED_LIBS)
@@ -43,9 +44,8 @@ else()
   target_compile_definitions(boost_container PUBLIC BOOST_CONTAINER_STATIC_LINK)
 endif()
 
-option(BUILD_TESTING "" ${PROJECT_IS_TOP_LEVEL})
 if(BUILD_TESTING AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/test/CMakeLists.txt")
-  enable_testing()
 
   add_subdirectory(test)
+
 endif()

--- a/cmake/boost_test.cmake
+++ b/cmake/boost_test.cmake
@@ -1,0 +1,131 @@
+# Copyright 2018 Peter Dimov
+# Distributed under the Boost Software License, Version 1.0.
+# See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt
+
+function(boost_test)
+
+  cmake_parse_arguments(
+    _
+    ""
+    "TYPE;PREFIX;NAME"
+    "SOURCES;LIBRARIES;ARGUMENTS"
+    ${ARGN}
+  )
+
+  if(NOT __TYPE)
+    set(__TYPE run)
+  endif()
+
+  if(NOT __PREFIX)
+    set(__PREFIX ${PROJECT_NAME})
+  endif()
+
+  if(NOT __NAME)
+    list(GET __SOURCES 0 __NAME)
+    string(MAKE_C_IDENTIFIER ${__NAME} __NAME)
+  endif()
+
+  set(__NAME ${__PREFIX}-${__NAME})
+
+  if(__TYPE STREQUAL "compile" OR __TYPE STREQUAL "compile-fail")
+
+    add_library(${__NAME} EXCLUDE_FROM_ALL ${__SOURCES})
+    target_link_libraries(${__NAME} ${__LIBRARIES})
+
+    add_test(NAME compile-${__NAME} COMMAND "${CMAKE_COMMAND}" --build ${CMAKE_BINARY_DIR} --target ${__NAME})
+
+    if(__TYPE STREQUAL "compile-fail")
+      set_tests_properties(compile-${__NAME} PROPERTIES WILL_FAIL TRUE)
+    endif()
+
+  elseif(__TYPE STREQUAL "link")
+
+    add_executable(${__NAME} EXCLUDE_FROM_ALL ${__SOURCES})
+    target_link_libraries(${__NAME} ${__LIBRARIES})
+
+    add_test(NAME link-${__NAME} COMMAND "${CMAKE_COMMAND}" --build ${CMAKE_BINARY_DIR} --target ${__NAME})
+
+  elseif(__TYPE STREQUAL "link-fail")
+
+    add_library(compile-${__NAME} EXCLUDE_FROM_ALL ${__SOURCES})
+    target_link_libraries(compile-${__NAME} ${__LIBRARIES})
+
+    add_test(NAME compile-${__NAME} COMMAND "${CMAKE_COMMAND}" --build ${CMAKE_BINARY_DIR} --target compile-${__NAME})
+
+    add_executable(${__NAME} EXCLUDE_FROM_ALL ${__SOURCES})
+    target_link_libraries(${__NAME} ${__LIBRARIES})
+
+    add_test(NAME link-${__NAME} COMMAND "${CMAKE_COMMAND}" --build ${CMAKE_BINARY_DIR} --target ${__NAME})
+    set_tests_properties(link-${__NAME} PROPERTIES WILL_FAIL TRUE)
+
+  elseif(__TYPE STREQUAL "run" OR __TYPE STREQUAL "run-fail")
+
+    add_executable(${__NAME} ${__SOURCES})
+    target_link_libraries(${__NAME} ${__LIBRARIES})
+
+    add_test(NAME compile-${__NAME} COMMAND "${CMAKE_COMMAND}" --build ${CMAKE_BINARY_DIR} --target ${__NAME})
+
+    message(TRACE "add_test(${__NAME})")
+    add_test(NAME run-${__NAME} COMMAND ${__NAME} ${__ARGUMENTS})
+    set_tests_properties(run-${__NAME} PROPERTIES DEPENDS compile-${__NAME})
+
+    if(__TYPE STREQUAL "run-fail")
+      set_tests_properties(run-${__NAME} PROPERTIES WILL_FAIL TRUE)
+    endif()
+
+  endif()
+
+endfunction()
+
+function(boost_test_jamfile)
+
+  cmake_parse_arguments(
+    _
+    ""
+    "FILE;PREFIX"
+    "LIBRARIES"
+    ${ARGN}
+  )
+
+  file(STRINGS ${__FILE} data)
+
+  set(types
+      compile
+      compile-fail
+      link
+      link-fail
+      run
+      run-fail
+  )
+
+  foreach(line IN LISTS data)
+    if(line)
+
+      string(REGEX MATCHALL "[^ ]+" ll ${line})
+
+      if(ll)
+        list(GET ll 0 e0)
+
+        if(e0 IN_LIST types)
+
+          list(LENGTH ll lln)
+
+          if(NOT lln EQUAL 2)
+
+            message(WARNING "Jamfile line ignored: ${line}")
+
+          else()
+
+            list(GET ll 1 e1)
+            message(TRACE "boost_test(PREFIX ${__PREFIX} TYPE ${e0} SOURCES ${e1} LIBRARIES ${__LIBRARIES})")
+            boost_test(PREFIX ${__PREFIX} TYPE ${e0} SOURCES ${e1} LIBRARIES ${__LIBRARIES})
+
+          endif()
+        endif()
+      else()
+        message(WARNING "${line}")
+      endif()
+    endif()
+  endforeach()
+
+endfunction()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,0 +1,7 @@
+include(../cmake/boost_test.cmake)
+
+file(GLOB_RECURSE sources "${CMAKE_CURRENT_SOURCE_DIR}/*.cpp")
+
+foreach(file IN LISTS sources)
+  boost_test(TYPE run SOURCES ${file} LIBRARIES boost_container)
+endforeach()

--- a/test/vector_test.hpp
+++ b/test/vector_test.hpp
@@ -232,20 +232,20 @@ bool vector_copyable_only(MyBoostVector &boostvector, MyStdVector &stdvector, bo
    //operator=
    {
       //Copy constructor test
-      MyBoostVector bcopy((const MyBoostVector&) boostvector);
+      MyBoostVector bcopy1((const MyBoostVector&) boostvector);
       MyStdVector   scopy((const MyStdVector&)   stdvector);
       MyBoostVector bcopy2(boostvector);
       MyStdVector   scopy2(stdvector);
 
-      if(!test::CheckEqualContainers(bcopy, scopy)) return false;
+      if(!test::CheckEqualContainers(bcopy1, scopy)) return false;
       if(!test::CheckEqualContainers(bcopy2, scopy2)) return false;
 
       //Assignment from a smaller vector
       bcopy2.erase(bcopy2.begin() + difference_type(bcopy2.size()/2), bcopy2.end());
       scopy2.erase(scopy2.begin() + difference_type(scopy2.size()/2), scopy2.end());
-      bcopy = bcopy2;
+      bcopy1 = bcopy2;
       scopy = scopy2;
-      if(!test::CheckEqualContainers(bcopy, scopy)) return false;
+      if(!test::CheckEqualContainers(bcopy1, scopy)) return false;
 
       //Assignment from a bigger vector with capacity
       bcopy2  = boostvector;
@@ -260,7 +260,7 @@ bool vector_copyable_only(MyBoostVector &boostvector, MyStdVector &stdvector, bo
 
       bcopy2 = boostvector;
       scopy2 = stdvector;
-      if(!test::CheckEqualContainers(bcopy, scopy)) return false;
+      if(!test::CheckEqualContainers(bcopy1, scopy)) return false;
 
       //Assignment with equal capacity
       bcopy2 = boostvector;


### PR DESCRIPTION
prevent name conflict with `bcopy` macro found in `strings.h` on some
unix systems, i.e. **android**