### PR TITLE
Fix incomplete type error when using list with pair

### DIFF
--- a/include/boost/container/list.hpp
+++ b/include/boost/container/list.hpp
@@ -32,6 +32,7 @@
 #include <boost/container/detail/iterators.hpp>
 #include <boost/container/detail/mpl.hpp>
 #include <boost/container/detail/node_alloc_holder.hpp>
+#include <boost/container/detail/pair.hpp>
 #include <boost/container/detail/version_type.hpp>
 #include <boost/container/detail/value_functors.hpp>
 // move


### PR DESCRIPTION
Example:

```
boost::container::list<std::pair<int, int>> list;
```
```
.../boost/container/allocator_traits.hpp:403:11: error: invalid use of incomplete type 'struct boost::container::dtl::pair<int, int>'
  403 |    {  p->~T(); (void)p;  }
      |       ~~~~^
In file included from .../boost/container/detail/node_alloc_holder.hpp:39,
                 from .../boost/container/list.hpp:34:
.../boost/container/detail/is_pair.hpp:59:8: note: declaration of 'struct boost::container::dtl::pair<int, int>'
   59 | struct pair;
      |        ^~~~
```