### PR TITLE
Remove deprecated unnecessary ATOMIC_VAR_INIT

### DIFF
--- a/src/global_resource.cpp
+++ b/src/global_resource.cpp
@@ -127,8 +127,8 @@ namespace boost {
 namespace container {
 namespace pmr {
 
-static std::atomic<memory_resource*> default_memory_resource = 
-   &boost::container::dtl::singleton_default<new_delete_resource_imp>::instance();
+static std::atomic<memory_resource*> default_memory_resource( 
+   &boost::container::dtl::singleton_default<new_delete_resource_imp>::instance());
 
 BOOST_CONTAINER_DECL memory_resource* set_default_resource(memory_resource* r) BOOST_NOEXCEPT
 {

--- a/src/global_resource.cpp
+++ b/src/global_resource.cpp
@@ -128,7 +128,7 @@ namespace container {
 namespace pmr {
 
 static std::atomic<memory_resource*> default_memory_resource = 
-   ATOMIC_VAR_INIT(&boost::container::dtl::singleton_default<new_delete_resource_imp>::instance());
+   &boost::container::dtl::singleton_default<new_delete_resource_imp>::instance();
 
 BOOST_CONTAINER_DECL memory_resource* set_default_resource(memory_resource* r) BOOST_NOEXCEPT
 {


### PR DESCRIPTION
`ATOMIC_VAR_INIT` has always been unnecessary (it does the same as the converting ctor of `std::atomic`) and is deprecated in C++20.

This causes build failure for clang/libc++/Wall.

Use direct-initialization syntax so that it works in pre-C++17 (?) mode

ref. #211 