### PR TITLE
Fix using pmr::polymorphic_allocator in pre-main

### DIFF
--- a/src/global_resource.cpp
+++ b/src/global_resource.cpp
@@ -127,17 +127,19 @@ namespace boost {
 namespace container {
 namespace pmr {
 
-static std::atomic<memory_resource*> default_memory_resource = 
-   ATOMIC_VAR_INIT(&boost::container::dtl::singleton_default<new_delete_resource_imp>::instance());
+std::atomic<memory_resource*>& default_memory_resource_instance() {
+    static std::atomic<memory_resource*> instance = new_delete_resource();
+    return instance;
+}
 
 BOOST_CONTAINER_DECL memory_resource* set_default_resource(memory_resource* r) BOOST_NOEXCEPT
 {
    memory_resource *const res = r ? r : new_delete_resource();
-   return default_memory_resource.exchange(res, std::memory_order_acq_rel);
+   return default_memory_resource_instance().exchange(res, std::memory_order_acq_rel);
 }
 
 BOOST_CONTAINER_DECL memory_resource* get_default_resource() BOOST_NOEXCEPT
-{  return default_memory_resource.load(std::memory_order_acquire); }
+{  return default_memory_resource_instance().load(std::memory_order_acquire); }
 
 #endif
 


### PR DESCRIPTION
A similar problems for the above (i. e. non-atomic) branch was addressed in #148, yet the default C++11 branch causes segfault with the following stacktrace:

```
(gdb) bt
#0  0x000000000e1c3d28 in boost::container::pmr::memory_resource::allocate (this=0x0, bytes=92, alignment=4)
    at boost/container/include/boost/container/pmr/memory_resource.hpp:48
#1  0x000000000e2e9e59 in boost::container::pmr::polymorphic_allocator<float>::allocate (this=0x7fffffffd148, n=23)
    at boost/container/include/boost/container/pmr/polymorphic_allocator.hpp:92
#2  0x000000000e2e9cdd in std::__y1::allocator_traits<boost::container::pmr::polymorphic_allocator<float> >::allocate (__a=..., __n=23)
    at libcxx/include/__memory/allocator_traits.h:262
#3  0x000000000e2e9b13 in std::__y1::vector<float, boost::container::pmr::polymorphic_allocator<float> >::__vallocate (this=0x7fffffffd130, __n=23)
    at libcxx/include/vector:958
#4  0x000000000e33c591 in std::__y1::vector<float, boost::container::pmr::polymorphic_allocator<float> >::vector (this=0x7fffffffd130, __n=23)
    at libcxx/include/vector:1106
```