### PR TITLE
Make static_vector<T,N> trivially relocatable when T is trivially relocatable

### DIFF
--- a/doc/Jamfile.v2
+++ b/doc/Jamfile.v2
@@ -42,6 +42,7 @@ doxygen autodoc
                                    \"BOOST_COPY_ASSIGN_REF(T)=const T &\" \\
                                    \"BOOST_FWD_REF(a)=a &&\" \\
                                    \"BOOST_CONTAINER_ATTRIBUTE_NODISCARD=[[nodiscard]] \" \\
+                                   \"BOOST_CONTAINER_ATTRIBUTE_TRIVIALLY_RELOCATABLE_IF=\" \\
                                    \"BOOST_NORETURN=[[noreturn]] \" \\
                                    \"BOOST_INTRUSIVE_OPTION_CONSTANT(OPTION_NAME, TYPE, VALUE, CONSTANT_NAME)   = template<TYPE VALUE> struct OPTION_NAME{};\" \\
                                    \"BOOST_INTRUSIVE_OPTION_TYPE(OPTION_NAME, TYPE, TYPEDEF_EXPR, TYPEDEF_NAME) = template<class TYPE> struct OPTION_NAME{};\" \\

--- a/include/boost/container/detail/type_traits.hpp
+++ b/include/boost/container/detail/type_traits.hpp
@@ -68,6 +68,14 @@ using ::boost::move_detail::natN;
 using ::boost::move_detail::max_align_t;
 using ::boost::move_detail::is_convertible;
 
+// TODO: Move this trait into <boost/move/detail/type_traits.hpp>
+
+#if __cpp_lib_trivially_relocatable
+  using ::std::is_trivially_relocatable;
+#else
+  template <class T> struct is_trivially_relocatable : std::is_trivially_copyable<T> {};
+#endif
+
 }  //namespace dtl {
 }  //namespace container {
 }  //namespace boost {

--- a/include/boost/container/static_vector.hpp
+++ b/include/boost/container/static_vector.hpp
@@ -149,7 +149,7 @@ struct get_static_vector_allocator
 //!@tparam Options A type produced from \c boost::container::static_vector_options. If no option
 //! is specified, by default throw_on_overflow<true> option is set.
 template <typename T, std::size_t Capacity, class Options BOOST_CONTAINER_DOCONLY(= void) >
-class static_vector
+class BOOST_CONTAINER_ATTRIBUTE_TRIVIALLY_RELOCATABLE_IF(dtl::is_trivially_relocatable<T>::value) static_vector
     : public vector<T, typename dtl::get_static_vector_allocator< T, Capacity, Options>::type>
 {
    public:


### PR DESCRIPTION
This PR definitely isn't ready for prime time, but I figured I might as well exploit Cunningham's Law here.

The idea is that when the compiler supports `__cpp_impl_trivially_relocatable` (P1144's proposed feature-test macro), then we should define `-DBOOST_CONTAINER_ATTRIBUTE_TRIVIALLY_RELOCATABLE_IF(x)=[[trivially_relocatable(x)]]`. (And/or set it to a vendor-specific attribute if-and-when anyone supports a vendor-specific attribute; no mainstream compiler does, yet.)

The big problem with this patch as it stands right now is that I have no idea where these macros are configured. We want to do the same thing that `BOOST_CONTAINER_ATTRIBUTE_NODISCARD` does; but that's not configured anywhere in this repo, either.

I see that Boost.Container is just inheriting all its type-traits from Boost.Move, so probably `dtl::is_trivially_relocatable` belongs in Boost.Move, not here?

Fixes #258.