### PR TITLE
Make `if` statements `constexpr` for flags known at compile time

### DIFF
--- a/include/boost/container/deque.hpp
+++ b/include/boost/container/deque.hpp
@@ -876,7 +876,7 @@ class deque : protected deque_base<typename real_allocator<T, Allocator>::type, 
          const bool allocators_equal = this_alloc == x_alloc; (void)allocators_equal;
          //Resources can be transferred if both allocators are
          //going to be equal after this function (either propagated or already equal)
-         if(propagate_alloc || allocators_equal){
+         BOOST_IF_CONSTEXPR(propagate_alloc || allocators_equal){
             //Destroy objects but retain memory in case x reuses it in the future
             this->clear();
             //Move allocator if needed
@@ -2043,7 +2043,7 @@ class deque : protected deque_base<typename real_allocator<T, Allocator>::type, 
 
    void priv_destroy_range(iterator p, iterator p2)
    {
-      if(!Base::traits_t::trivial_dctr){
+      BOOST_IF_CONSTEXPR(!Base::traits_t::trivial_dctr){
          for(;p != p2; ++p){
             allocator_traits_type::destroy(this->alloc(), boost::movelib::iterator_to_raw_pointer(p));
          }
@@ -2052,7 +2052,7 @@ class deque : protected deque_base<typename real_allocator<T, Allocator>::type, 
 
    void priv_destroy_range(pointer p, pointer p2)
    {
-      if(!Base::traits_t::trivial_dctr){
+      BOOST_IF_CONSTEXPR(!Base::traits_t::trivial_dctr){
          for(;p != p2; ++p){
             allocator_traits_type::destroy(this->alloc(), boost::movelib::iterator_to_raw_pointer(p));
          }

--- a/include/boost/container/list.hpp
+++ b/include/boost/container/list.hpp
@@ -351,7 +351,7 @@ class list
          const bool allocators_equal = this_alloc == x_alloc; (void)allocators_equal;
          //Resources can be transferred if both allocators are
          //going to be equal after this function (either propagated or already equal)
-         if(propagate_alloc || allocators_equal){
+         BOOST_IF_CONSTEXPR(propagate_alloc || allocators_equal){
             //Destroy
             this->clear();
             //Move allocator if needed

--- a/include/boost/container/node_handle.hpp
+++ b/include/boost/container/node_handle.hpp
@@ -231,7 +231,7 @@ class node_handle
       if(was_nh_non_null){
          if(was_this_non_null){
             this->destroy_deallocate_node();
-            if(nator_traits::propagate_on_container_move_assignment::value){
+            BOOST_IF_CONSTEXPR(nator_traits::propagate_on_container_move_assignment::value){
                this->node_alloc() = ::boost::move(nh.node_alloc());
             }
          }
@@ -335,7 +335,7 @@ class node_handle
 
       if(was_nh_non_null){
          if(was_this_non_null){
-            if(nator_traits::propagate_on_container_swap::value){
+            BOOST_IF_CONSTEXPR(nator_traits::propagate_on_container_swap::value){
                ::boost::adl_move_swap(this->node_alloc(), nh.node_alloc());
             }
          }

--- a/include/boost/container/slist.hpp
+++ b/include/boost/container/slist.hpp
@@ -377,7 +377,7 @@ class slist
          const bool allocators_equal = this_alloc == x_alloc; (void)allocators_equal;
          //Resources can be transferred if both allocators are
          //going to be equal after this function (either propagated or already equal)
-         if(propagate_alloc || allocators_equal){
+         BOOST_IF_CONSTEXPR(propagate_alloc || allocators_equal){
             //Destroy
             this->clear();
             //Move allocator if needed

--- a/include/boost/container/stable_vector.hpp
+++ b/include/boost/container/stable_vector.hpp
@@ -882,7 +882,7 @@ class stable_vector
          const bool allocators_equal = this_alloc == x_alloc; (void)allocators_equal;
          //Resources can be transferred if both allocators are
          //going to be equal after this function (either propagated or already equal)
-         if(propagate_alloc || allocators_equal){
+         BOOST_IF_CONSTEXPR(propagate_alloc || allocators_equal){
             BOOST_CONTAINER_STABLE_VECTOR_CHECK_INVARIANT
             //Destroy objects but retain memory in case x reuses it in the future
             this->clear();

--- a/include/boost/container/string.hpp
+++ b/include/boost/container/string.hpp
@@ -921,7 +921,7 @@ class basic_string
          const bool allocators_equal = this_alloc == x_alloc; (void)allocators_equal;
          //Resources can be transferred if both allocators are
          //going to be equal after this function (either propagated or already equal)
-         if(propagate_alloc || allocators_equal){
+         BOOST_IF_CONSTEXPR(propagate_alloc || allocators_equal){
             //Destroy objects but retain memory in case x reuses it in the future
             this->clear();
             //Move allocator if needed


### PR DESCRIPTION
I am trying to move-assign one container to the other:
```
void func(boost::container::deque<T>& deque1){
boost::container::deque<T> deque2;
// Fill deque2 with elements.
...
deque1 = std::move(deque2);
}
```
If `T` is neither move nor copy constructable, this code does not compile. However, it should and compiles for `std` containers, because it is possible to just pass memory ownership from `deque2` to `deque1` since their allocators are the same. The problem is that the choice between transferring resources or moving the elements one by one is written using ordinary `if`. The compiler generates the error when checking the second option even though it is not used. With `if constexpr` instead of `if` the statement is resolved at compile time and no error is generated.

I propose changing `if` statements for flags known at compile time to `if constexpr` using `BOOST_IF_CONSTEXPR`.