### PR TITLE
Improve description of stored_size

### DIFF
--- a/doc/container.qbk
+++ b/doc/container.qbk
@@ -1,5 +1,5 @@
 [/
- / Copyright (c) 2009-2020 Ion Gaztañaga
+ / Copyright (c) 2009-2020 Ion GaztaÃ±aga
  /
  / Distributed under the Boost Software License, Version 1.0. (See accompanying
  / file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -743,10 +743,10 @@ the last template parameter and defined using the utility class
    [classref boost::container::growth_factor_100 growth_factor_100].
 
 *  [classref boost::container::stored_size stored_size]: the type that will be used to store size-related
-   parameters inside of the vector. Sometimes, when the maximum capacity to be used is much less than the
-   theoretical maximum that a vector can hold, it's interesting to use smaller unsigned integer types to represent
-   `size()` and `capacity()` inside vector, so that the size of an empty vector is minimized and cache 
-   performance might be improved. See [classref boost::container::stored_size stored_size] for more details.
+   parameters inside the vector. Sometimes, when the maximum vector capacity to be used is much less than
+   `std::size_t` capacity, it may be beneficial to use a smaller unsigned integer type to represent
+   `size()` and `capacity()` values inside the vector, so that the size of an empty vector object is minimized and cache 
+   performance is possibly improved. See [classref boost::container::stored_size stored_size] for more details.
 
 See the following example to see how [classref boost::container::vector_options vector_options] can be
 used to customize `vector`:
@@ -767,14 +767,14 @@ the last template parameter and defined using the utility class
 
 *  [classref boost::container::throw_on_overflow throw_on_overflow]: A boolean that specifies if the
    container should throw an exception when the compile-time capacity is not enough to hold the requesteed number
-   of objects. When "false", if the capacit is overflowed, the implementation calls to BOOST_ASSERT and if that assertion
+   of objects. When "false", if the capacit is overflowed, the implementation calls to `BOOST_ASSERT` and if that assertion
    does not throw or abort, undefined behavior is triggered.
 
 *  [classref boost::container::stored_size stored_size]: the type that will be used to store size-related
-   parameters inside of the vector. Sometimes, when the static to be used is much less than `std::size_t`
-   it's interesting to use a smaller unsigned integer types to represent `size()` inside `static_vector``,
-   so that the size of an empty vector is minimized and cache 
-   performance might be improved. See [classref boost::container::stored_size stored_size] for more details.
+   parameters inside the vector. Sometimes, when the static size to be used is much less than `std::size_t` capacity,
+   it may be beneficial to use a smaller unsigned integer type to represent the `size()` value inside `static_vector`,
+   so that the object size of an empty vector is minimized and cache 
+   performance is possibly improved. See [classref boost::container::stored_size stored_size] for more details.
 
 See the following example to see how [classref boost::container::static_vector_options static_vector_options] can be
 used to customize `static_vector`:
@@ -804,10 +804,10 @@ the last template parameter and defined using the utility class
    [classref boost::container::growth_factor_50 growth_factor_100].
 
 *  [classref boost::container::stored_size stored_size]: the type that will be used to store size-related
-   parameters inside of the vector. Sometimes, when the maximum capacity to be used is much less than the
-   theoretical maximum that a vector can hold, it's interesting to use smaller unsigned integer types to represent
-   `size()` and `capacity()` inside vector, so that the size of an empty vector is minimized and cache 
-   performance might be improved. See [classref boost::container::stored_size stored_size] for more details.
+   parameters inside the vector. Sometimes, when the maximum vector capacity to be used is much less than
+   `std::size_t` capacity, it may be beneficial to use a smaller unsigned integer type to represent
+   `size()` and `capacity()` values inside the vector, so that the size of an empty vector object is minimized and cache 
+   performance is possibly improved. See [classref boost::container::stored_size stored_size] for more details.
 
 See the following example to see how [classref boost::container::small_vector_options small_vector_options] can be
 used to customize `small_vector`:
@@ -858,10 +858,10 @@ the last template parameter and defined using the utility class
    [classref boost::container::growth_factor_100 growth_factor_100].
 
 *  [classref boost::container::stored_size stored_size]: the type that will be used to store size-related
-   parameters inside of the devector. Sometimes, when the maximum capacity to be used is much less than the
-   theoretical maximum that a devector can hold, it's interesting to use smaller unsigned integer types to represent
-   `size()` and `capacity()` inside devector, so that the size of an empty devector is minimized and cache 
-   performance might be improved. See [classref boost::container::stored_size stored_size] for more details.
+   parameters inside of the devector. Sometimes, when the maximum devector capacity to be used is much less than
+   `std::size_t` capacity, it may be beneficial to use a smaller unsigned integer type to represent
+   `size()` and `capacity()` values inside the devector, so that the size of an empty devector object is minimized and cache 
+   performance is possibly improved. See [classref boost::container::stored_size stored_size] for more details.
 
 *  [classref boost::container::relocate_on_66 relocate_on_XX]: load factor limit that will determine if
    new memory should be allocated or elements should relocated inside existing memory, when the free space


### PR DESCRIPTION
This improves wording of `stored_size` parameter descriptions and also fixes QuickBook syntax.