### PR TITLE
CMake: Add option to use header-only `Boost::container`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,22 +6,31 @@ cmake_minimum_required(VERSION 3.5...3.16)
 
 project(boost_container VERSION "${BOOST_SUPERPROJECT_VERSION}" LANGUAGES C CXX)
 
-add_library(boost_container
-  src/alloc_lib.c
-  src/dlmalloc.cpp
-  src/global_resource.cpp
-  src/monotonic_buffer_resource.cpp
-  src/pool_resource.cpp
-  src/synchronized_pool_resource.cpp
-  src/unsynchronized_pool_resource.cpp
-)
+option(BOOST_CONTAINER_HEADER_ONLY "Disable Extended Allocators and some Polymorphic Memory Resources classes" OFF)
+
+if(BOOST_CONTAINER_HEADER_ONLY)
+  add_library(boost_container INTERFACE)
+  set(_populate INTERFACE)
+else()
+  add_library(boost_container
+    src/alloc_lib.c
+    src/dlmalloc.cpp
+    src/global_resource.cpp
+    src/monotonic_buffer_resource.cpp
+    src/pool_resource.cpp
+    src/synchronized_pool_resource.cpp
+    src/unsynchronized_pool_resource.cpp
+  )
+  set(_populate PUBLIC)
+endif()
+
 
 add_library(Boost::container ALIAS boost_container)
 
-target_include_directories(boost_container PUBLIC include)
+target_include_directories(boost_container ${_populate} include)
 
 target_link_libraries(boost_container
-  PUBLIC
+  ${_populate}
     Boost::assert
     Boost::config
     Boost::intrusive
@@ -29,15 +38,17 @@ target_link_libraries(boost_container
 )
 
 target_compile_definitions(boost_container
-  PUBLIC BOOST_CONTAINER_NO_LIB
+  ${_populate} BOOST_CONTAINER_NO_LIB
   # Source files already define BOOST_CONTAINER_SOURCE
   # PRIVATE BOOST_CONTAINER_SOURCE
 )
 
-if(BUILD_SHARED_LIBS)
-  target_compile_definitions(boost_container PUBLIC BOOST_CONTAINER_DYN_LINK)
-else()
-  target_compile_definitions(boost_container PUBLIC BOOST_CONTAINER_STATIC_LINK)
+if(NOT BOOST_CONTAINER_HEADER_ONLY)
+  if(BUILD_SHARED_LIBS)
+    target_compile_definitions(boost_container ${_populate} BOOST_CONTAINER_DYN_LINK)
+  else()
+    target_compile_definitions(boost_container ${_populate} BOOST_CONTAINER_STATIC_LINK)
+  endif()
 endif()
 
 if(BUILD_TESTING AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/test/CMakeLists.txt")


### PR DESCRIPTION
[`Boost::container` is declared as a header-only library](https://www.boost.org/doc/libs/1_86_0/doc/html/container.html#container.intro.introduction_building_container). So a header-only option is needed.