### PR TITLE
fix: severe warning of aggressive loop optimizations

### DIFF
--- a/src/dlmalloc_ext_2_8_6.c
+++ b/src/dlmalloc_ext_2_8_6.c
@@ -1038,8 +1038,8 @@ static int internal_multialloc_arrays
    }
 
    {
-      size_t    i;
-      size_t next_i;
+      ssize_t    i;
+      ssize_t next_i;
       /*
          Allocate the aggregate chunk.  First disable direct-mmapping so
          malloc won't use it, since we would not be able to later


### PR DESCRIPTION
This small patch fixes the severe warning:
/var/tmp/portage/dev-libs/boost-1.88.0-r1/work/boost_1_88_0-abi_x86_64.amd64/libs/container/src/dlmalloc_ext_2_8_6.c:1085:23: warning: iteration 2305843009213693951 invokes undefined behavior [-Waggressive-loop-optimizations]
I got when compiling with gcc-15