### PR TITLE
__cpp_sized_deallocation is not always defined (clang is opt-in) for Issue #306

### DIFF
--- a/include/boost/container/new_allocator.hpp
+++ b/include/boost/container/new_allocator.hpp
@@ -163,7 +163,7 @@ class new_allocator
    void deallocate(pointer ptr, size_type n) BOOST_NOEXCEPT_OR_NOTHROW
    {
       (void)n;
-      # if __cpp_sized_deallocation
+      # if defined(__cpp_sized_deallocation)
       ::operator delete((void*)ptr, n * sizeof(T));
       #else
       ::operator delete((void*)ptr);

--- a/test/allocator_argument_tester.hpp
+++ b/test/allocator_argument_tester.hpp
@@ -74,7 +74,7 @@ class propagation_test_allocator
    void deallocate(value_type *ptr, std::size_t n)
    {
       (void)n;
-      # if __cpp_sized_deallocation
+      # if defined(__cpp_sized_deallocation)
       ::operator delete((void*)ptr, n * sizeof(value_type));
       #else
       ::operator delete((void*)ptr);

--- a/test/dummy_test_allocator.hpp
+++ b/test/dummy_test_allocator.hpp
@@ -65,7 +65,7 @@ class simple_allocator
    void deallocate(T *ptr, std::size_t n) BOOST_NOEXCEPT_OR_NOTHROW
    {
       (void)n;
-      # if __cpp_sized_deallocation
+      # if defined(__cpp_sized_deallocation)
       ::operator delete((void*)ptr, n * sizeof(T));
       #else
       ::operator delete((void*)ptr);
@@ -187,7 +187,7 @@ class propagation_test_allocator
    void deallocate(T *ptr, std::size_t n) BOOST_NOEXCEPT_OR_NOTHROW
    {
       (void)n;
-      # if __cpp_sized_deallocation
+      # if defined(__cpp_sized_deallocation)
       ::operator delete((void*)ptr, n * sizeof(T));
       #else
       ::operator delete((void*)ptr);

--- a/test/explicit_inst_vector_test.cpp
+++ b/test/explicit_inst_vector_test.cpp
@@ -38,7 +38,7 @@ class CustomAllocator
 	void deallocate(pointer ptr, size_type n)
    {
       (void)n;
-      # if __cpp_sized_deallocation
+      # if defined(__cpp_sized_deallocation)
       ::operator delete((void*)ptr, n * sizeof(value_type));
       #else
       ::operator delete((void*)ptr);


### PR DESCRIPTION
In reference to Issue #306 

I noticed on Ubuntu 24.04 that gcc defines `__cpp_sized_deallocation` but clang does not, unless [opted into](https://bcain-llvm.readthedocs.io/projects/clang/en/release_37/ReleaseNotes/#new-compiler-flags).

So I agree that these checks should be refined to `#if defined()`