### PR TITLE
Add Doxygen docs to gcd() and improve vector example comments

### DIFF
--- a/example/doc_custom_vector.cpp
+++ b/example/doc_custom_vector.cpp
@@ -26,6 +26,9 @@ int main ()
 
    //This option specifies that a vector that will use "unsigned char" as
    //the type to store capacity or size internally.
+   //Note: You can also use 'unsigned short' (saves 6 bytes, max size 65,535),
+   //'unsigned int' (saves 4 bytes, max size ~4 billion), etc.
+   //This trades memory efficiency for maximum representable capacity.
    typedef vector_options< stored_size<unsigned char> >::type size_option_t;
 
    //Size-optimized vector is smaller than the default one.

--- a/include/boost/container/detail/math_functions.hpp
+++ b/include/boost/container/detail/math_functions.hpp
@@ -33,14 +33,23 @@ namespace boost {
 namespace container {
 namespace dtl {
 
-// Greatest common divisor and least common multiple
+//! Calculates greatest common divisor using Euclid's algorithm
+//! 
+//! @tparam Integer Integral type supporting modulo and comparison
+//! @param A First positive integer (recommended: A > B for efficiency)
+//! @param B Second positive integer
+//! @return GCD of A and B
+//! @pre A > 0 && B > 0
+//! 
+//! @par Complexity:
+//! O(log(min(A,B))) worst case
+//!
+//! @par Example:
+//! @code
+//! std::size_t g = gcd(48, 18); // returns 6
+//! std::size_t h = gcd(100, 35); // returns 5
+//! @endcode
 
-//
-// gcd is an algorithm that calculates the greatest common divisor of two
-//  integers, using Euclid's algorithm.
-//
-// Pre: A > 0 && B > 0
-// Recommended: A > B
 template <typename Integer>
 inline Integer gcd(Integer A, Integer B)
 {


### PR DESCRIPTION
# Documentation Enhancements

The stored_size option is powerful but easy to misinterpret as being limited to unsigned char.
A short note helps users understand that they can choose a larger integral type when they need more capacity while still reducing overhead compared to size_t.

The gcd() function already had informal comments; converting them to structured Doxygen makes the intent, preconditions, and complexity clearer and consistent with the rest of the codebase.

Both changes are documentation-only and do not affect  runtime behavior.

# Summary
This PR makes two small documentation improvements in Boost.Container:
            **1**.Clarifies the stored_size option in doc_custom_vector.cpp by explicitly mentioning alternative integral types **_(unsigned short, unsigned int)_** and the memory–capacity tradeoff they provide.
           **2**.Adds **_Doxygen-style documentation to the internal gcd()_** utility in math_functions.hpp, improving readability and generated reference docs without changing behavior.

# Additional note

I’m interested to spend more time contributing to Boost.Container and would be glad to focus on specific areas, documentation gaps, or small fixes that maintainers consider useful or high priority.