### PR TITLE
Remove std::pair specializations from pair.hpp (moved to Boost.Move)

### DIFF
--- a/include/boost/container/detail/pair.hpp
+++ b/include/boost/container/detail/pair.hpp
@@ -563,11 +563,6 @@ struct is_trivially_copy_assignable<boost::container::dtl::pair<A,B> >
                                        boost::move_detail::is_trivially_copy_assignable<B>::value;
 };
 
-template<class A, class B>
-struct is_trivially_copy_assignable<std::pair<A,B> >
-   : is_trivially_copy_assignable<boost::container::dtl::pair<A,B> >
-{};
-
 //
 // is_trivially_move_assignable
 //
@@ -581,12 +576,6 @@ struct is_trivially_move_assignable<boost::container::dtl::pair<A,B> >
    BOOST_STATIC_CONSTEXPR bool value = boost::move_detail::is_trivially_move_assignable<A>::value &&
                                        boost::move_detail::is_trivially_move_assignable<B>::value;
 };
-
-template<class A, class B>
-struct is_trivially_move_assignable<std::pair<A,B> >
-   : is_trivially_move_assignable<boost::container::dtl::pair<A,B> >
-{};
-
 
 //
 // is_trivially_copy_constructible
@@ -602,11 +591,6 @@ struct is_trivially_copy_constructible<boost::container::dtl::pair<A,B> >
                                        boost::move_detail::is_trivially_copy_constructible<B>::value;
 };
 
-template<class A, class B>
-struct is_trivially_copy_constructible<std::pair<A,B> >
-   : is_trivially_copy_constructible<boost::container::dtl::pair<A,B> >
-{};
-
 //
 // is_trivially_move_constructible
 //
@@ -621,11 +605,6 @@ struct is_trivially_move_constructible<boost::container::dtl::pair<A,B> >
                                        boost::move_detail::is_trivially_move_constructible<B>::value;
 };
 
-template<class A, class B>
-struct is_trivially_move_constructible<std::pair<A,B> >
-   : is_trivially_move_constructible<boost::container::dtl::pair<A,B> >
-{};
-
 template<class T>
 struct is_trivially_destructible;
 
@@ -635,11 +614,6 @@ struct is_trivially_destructible<boost::container::dtl::pair<A,B> >
    BOOST_STATIC_CONSTEXPR bool value = boost::move_detail::is_trivially_destructible<A>::value &&
                                        boost::move_detail::is_trivially_destructible<B>::value;
 };
-
-template<class A, class B>
-struct is_trivially_destructible<std::pair<A,B> >
-   : is_trivially_destructible<boost::container::dtl::pair<A,B> >
-{};
 
 }  //namespace move_detail{
 
@@ -652,11 +626,6 @@ struct has_trivial_destructor_after_move<boost::container::dtl::pair<A,B> >
    BOOST_STATIC_CONSTEXPR bool value = boost::has_trivial_destructor_after_move<A>::value &&
                                        boost::has_trivial_destructor_after_move<B>::value;
 };
-
-template<class A, class B>
-struct has_trivial_destructor_after_move<std::pair<A,B> >
-   : has_trivial_destructor_after_move<boost::container::dtl::pair<A,B> >
-{};
 
 }  //namespace boost {
 


### PR DESCRIPTION
Remove the std::pair<A,B> partial specializations for is_trivially_{destructible,copy_constructible,move_constructible, copy_assignable,move_assignable} and has_trivial_destructor_after_move from boost/container/detail/pair.hpp.

These specializations are now provided directly in the Boost.Move headers (type_traits.hpp and traits.hpp) alongside the primary template definitions.  Placing them in pair.hpp — which is included late in the include chain via flat_map.hpp — caused GCC to diagnose "partial specialization after instantiation" in unity/jumbo builds or any translation unit that implicitly instantiated a trait for std::pair before pair.hpp was included.

The dtl::pair specializations remain in pair.hpp since dtl::pair is defined in this header.

This is a coordinated fix with the corresponding Boost.Move change.

Fixes: https://github.com/boostorg/container/issues/330