### PR TITLE
optimized range insertion for `boost::container::hub`

### DIFF
--- a/include/boost/container/hub.hpp
+++ b/include/boost/container/hub.hpp
@@ -1936,10 +1936,14 @@ private:
       while(first != last) {
          int  n;
          auto pb = retrieve_available_block(n);
+         if(pb->mask == 0) {
+            //blocks used are empty from this point on (reserved or newly allocated)
+            range_insert_adjacent(first, last, construct_, pb);
+            return;
+         }
          for(; ; ) {
             construct_(boost::movelib::to_raw_pointer(pb->data() + n), first++);
             ++size_;
-            if(BOOST_UNLIKELY(pb->mask == 0)) blist.link_at_back(pb);
             pb->mask |= pb->mask +1;
             if(pb->mask == full) {
                blist.unlink_available(pb);
@@ -1948,6 +1952,46 @@ private:
             else if(first == last) return;
             n = dtl::unchecked_countr_one(pb->mask);
          }
+      }
+   }
+
+   template<typename Incrementable, typename Sentinel, typename Construct>
+   void range_insert_adjacent(
+      Incrementable& first, Sentinel last, Construct construct_, block_pointer pb)
+   {
+      for(;;) {
+         BOOST_ASSERT(pb->mask == 0);
+         T* p = boost::movelib::to_raw_pointer(pb->data());
+         int i = 0;
+         BOOST_CONTAINER_TRY {
+            for(;;) {
+               construct_(p + i, first++);
+               if(++i == N || first == last) break;
+            }
+         }
+         BOOST_CONTAINER_CATCH(...) {
+            if(i != 0) {
+               blist.link_at_back(pb);
+               size_ += (size_type)i;
+               pb->mask = (mask_type(1) << i) - 1;
+            }
+            BOOST_CONTAINER_RETHROW;
+         }
+         BOOST_CONTAINER_CATCH_END
+
+         blist.link_at_back(pb);
+         size_ += (size_type)i;
+         if(i == N) {
+            pb->mask = full;
+            blist.unlink_available(pb);
+         }
+         else {
+            pb->mask = (mask_type(1) << i) - 1;
+            return;
+         }
+         if(first == last) return;
+         int n;
+         pb = retrieve_available_block(n);
       }
    }
 


### PR DESCRIPTION
Optimizes range insertion taking advantage of the fact that insertion goes through all non-empty and non-full blocks first and then uses empty blocks exclusively. Current hub tests cover all the new code, including `catch` blocks.

Performance increase ([`perf.cpp`](https://gist.github.com/joaquintides/3ac86505607fe9c16e92b1df37bc3a9d), release mode):

 GCC 13

**Before**
```
n       t(regular insert) / t(range insert)
10E2    1.1193
10E3    1.14559
10E4    1.14469
10E5    1.18275
10E6    1.16951
```

**After**
```
n       t(regular insert) / t(range insert)
10E2    1.67431
10E3    1.38766
10E4    1.42388
10E5    1.71183
10E6    1.7539
```
 Clang 13 for Visual Studio (clang-cl)

**Before**
```
n       t(regular insert) / t(range insert)
10E2    1.16093
10E3    1.27721
10E4    1.1313
10E5    1.18809
10E6    1.2059
```

**After**
```
n       t(regular insert) / t(range insert)
10E2    1.65984
10E3    1.916
10E4    1.4827
10E5    1.6352
10E6    1.70056
```

VS 2022

**Before**
```
n       t(regular insert) / t(range insert)
10E2    1.25101
10E3    1.26594
10E4    1.16627
10E5    1.09216
10E6    1.21067
```

**After**
```
n       t(regular insert) / t(range insert)
10E2    1.41975
10E3    1.44301
10E4    1.30676
10E5    1.32164
10E6    1.38581
```
