### PR TITLE
Fix unqualified swap for small_vector

### DIFF
--- a/include/boost/container/small_vector.hpp
+++ b/include/boost/container/small_vector.hpp
@@ -1063,6 +1063,13 @@ class small_vector
    inline void swap(small_vector &other)
    {  return this->base_type::prot_swap(other, static_capacity);  }
 
+   //! <b>Effects</b>: x.swap(y)
+   //!
+   //! <b>Complexity</b>: Linear to the number of elements stored in the small buffers.
+   inline friend void swap(small_vector &x, small_vector &y)
+      BOOST_NOEXCEPT_IF(BOOST_NOEXCEPT(x.swap(y)))
+   {  x.swap(y);  }
+
    //! <b>Effects</b>: Tries to reduce capacity() to the current size(). Once the capacity
    //!   changes, the container permanently switches to dynamically allocated storage even if
    //!   the resulting size would fit in the internal buffer.

--- a/test/small_vector_test.cpp
+++ b/test/small_vector_test.cpp
@@ -295,6 +295,25 @@ bool test_small_vector_base_test()
 //small vector has internal storage so some special swap cases must be tested
 bool test_swap()
 {
+   {  //Unqualified swap must use small_vector's capacity-aware swap through ADL
+      typedef boost::container::small_vector<int, 2> small_vec;
+      small_vec v;
+      v.push_back(1);
+      v.push_back(11);
+
+      small_vec w;
+      w.push_back(2);
+      w.push_back(22);
+
+      small_vec v_copy = v;
+      small_vec w_copy = w;
+
+      swap(v, w);
+
+      if (w != v_copy || v != w_copy || !v.is_small() || !w.is_small())
+         return false;
+   }
+
    typedef boost::container::small_vector<int, 10> vec;
    {  //v bigger than static capacity, w empty
       vec v;


### PR DESCRIPTION
Unqualified `swap(a, b)` for two `small_vector` objects was resolved
to the hidden friend `swap` of the underlying `vector`. This caused
pointers to internal storage to be treated as dynamically allocated
storage and deallocated during destruction.

Add a hidden friend `swap` to `small_vector` that forwards to its
capacity-aware member `swap`.

A regression test verifies unqualified ADL swap when both vectors use
their internal storage.

Fixes #342.